### PR TITLE
Fix tests

### DIFF
--- a/render_engine/page.py
+++ b/render_engine/page.py
@@ -63,7 +63,7 @@ class Page:
         self.slug = slugify(self.slug)
 
     @property
-    def url(self) -> str:
+    def url(self) -> Path:
         """The first route and the slug of the page."""
         return (
             getattr(self, "output_path", Path("./"))
@@ -101,7 +101,7 @@ class Page:
     def _render_content(self, *, engine:Environment=None, **kwargs) -> str:
         # template = self._template
         template = engine.get_template(self.template)
-        
+
         if template:
             if self.content:
                 return template.render(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import typing
 from pathlib import Path
 
 import pytest
-from jinja2 import Template
+from jinja2 import Environment, FileSystemLoader, Template
 
 from render_engine.page import Page
 
@@ -63,6 +63,7 @@ def page_with_attrs():
 Test Paragraph"""
         custom_list = ["foo", "bar", "biz"]
         custom_attr = "this is an attribute"
+        template = Template("{{content}}")
 
     yield PageWithAttrs()
 
@@ -81,13 +82,15 @@ def page_with_content_path(temp_path, content):
 
 @pytest.fixture(scope="class", name="no_template")
 def render_page_no_template(temp_path, p_attrs):
-    p_attrs.render(path=temp_path)
+    engine = Environment(loader=FileSystemLoader(["templates"]))
+    p_attrs.render(engine=engine, path=temp_path)
     check_path = Path(temp_path / f"{p_attrs.slug}{p_attrs.extension}")
     yield check_path
 
 
 @pytest.fixture(scope="class", name="with_template")
 def render_page_template(temp_path, p_attrs):
-    p_attrs.render(path=temp_path, template=Template("foo{{content}}"))
+    engine = Environment(loader=FileSystemLoader(["templates"]))
+    p_attrs.render(engine=engine, path=temp_path)
     check_path = Path(temp_path / f"{p_attrs.slug}{p_attrs._extension}")
     yield check_path

--- a/tests/test_collection/test_collection.py
+++ b/tests/test_collection/test_collection.py
@@ -2,8 +2,11 @@ from pathlib import Path
 
 import pytest
 
-from render_engine.collection import Collection
+from jinja2 import Environment, FileSystemLoader
+
+from render_engine.collection import Collection, gen_collection
 from render_engine.page import Page
+from render_engine.site import render_archives
 
 
 def test_collections_discovers_title(base_collection, custom_collection):
@@ -42,9 +45,9 @@ def test_collection_with_bad_path_raises_error():
         BadPathCollection().pages()
 
 
-@pytest.mark.xfail(strict=True)
 def test_collection_render_archives_loaded(temp_dir_collection, base_collection):
-    base_collection.render_archives(path=temp_dir_collection)
+    engine = Environment(loader=FileSystemLoader(["templates"]))
+    render_archives(archive=base_collection.archives, engine=engine, path=temp_dir_collection)
     archive = temp_dir_collection.joinpath("mycollection.html")
     assert archive.exists()
     assert archive.read_text() == "Foo"

--- a/tests/test_collection/test_collection.py
+++ b/tests/test_collection/test_collection.py
@@ -15,9 +15,8 @@ def test_collections_accept_custom_vars(custom_collection):
     assert custom_collection.foo == "bar"
 
 
-@pytest.mark.xfail(strict=True)
 def test_collection_passes_vars_to_page(base_collection, temp_dir_collection):
-    assert base_collection.pages[0].collection_title == "MyCollection"
+    assert base_collection.pages[0].COLLECTION_TITLE == "MyCollection"
 
 
 def test_collection_pages_are_content_type(temp_dir_collection):

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -76,15 +76,12 @@ def test_custom_page_accepts_vars_in_init():
 
 
 class TestPageWritesToFile:
-    @pytest.mark.xfail(strict=True)
     def test_page_writes_to_file(self, no_template):
         """Given a Path with"""
         assert no_template.exists()
 
-    @pytest.mark.xfail(strict=True)
     def test_page_content_no_template_is_html(self, no_template, p_attrs):
         assert no_template.read_text() == p_attrs.content
 
-    @pytest.mark.xfail(strict=True)
     def test_page_with_tempate_is_rendered(self, with_template, p_attrs):
         assert with_template.read_text() == f"{p_attrs.content}"

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -54,13 +54,12 @@ class TestPageWithAttrs:
 
 
 class TestBasePage:
-    @pytest.mark.xfail(strict=True)
     def test_base_page_is_slug(self, page):
         """Tests if a slug is not provided then the slug will be a slugified
         version of the the class name"""
         assert page.slug == "basepage"
         assert str(page) == "basepage"
-        assert page.url == "./basepage.html"
+        assert page.url == Path("./basepage.html")
 
     def test_page_html_with_no_content_or_template_is_none(self, page):
         """If there is no content then the html will be None"""


### PR DESCRIPTION
Includes the following test fixes:

### Fix TestBasePage.test_base_page_is_slug

The return type of the `Page.url` property changed from a `str` to a
`Path` in 3d8b32038e3643176ab39009408a821084f593df. This change updates
the test to reflect that change and removes the `xfail` marker from the
now-passing test.

---

### Fix test_collection_passes_vars_to_page

A change was made in https://github.com/jonafato/render_engine/commit/3d8b32038e3643176ab39009408a821084f593df to convert
collection vars' keys to upper case when ' keys in the `collection_vars`
property. This change updates the test for the passthrough functionality
to reflect the new uppercase behavior.

---

### Fix test_collection_render_archives_loaded

`base_collection.render_archives` was removed in
https://github.com/jonafato/render_engine/commit/752356658f054330aa4f3c735029257514fb0c5e. This method's functionality
seems to have moved to `base_collection.archives` (a decorator that
generates the archives), `gen_collection` (a function that powers that
decorator), and `render_archives` (a function that does the actual
writing of the flat files). This change updates the relevant test to
resolve its failure.

Additionally, https://github.com/jonafato/render_engine/commit/f628b1833b4b846b0c59121a0073df023a42c780 removed `engine`
from pages and collections, so this test now includes an engine passed
explicitly into the `render_archives` call.

---

### Fix remaining tests

As of https://github.com/jonafato/render_engine/commit/f628b1833b4b846b0c59121a0073df023a42c780:

- `Page` classes require a `template` attribute
-  The `engine` attribute is removed from `Page` classes in favor of an
   `engine` argument passed to `render` function calls

This change updates test fixtures to resolve errors on tests that
require them and removes the `xfail` markers from now-passing tests.