### PR TITLE
Add missing documentation pages for referenced objects

### DIFF
--- a/docs/docs/collection.md
+++ b/docs/docs/collection.md
@@ -1,0 +1,1 @@
+::: render_engine.collection

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,9 +1,9 @@
 ## What is RenderEngine
 ## The _3 layer_ Architecture 
 
-* **[Page](render_engine/page.html)** - A single webpage item built from content, a template, raw data, or a combination of those things.
-* **[Collection](render_engine/collection.html)** - A group of webpages built from the same template, organized in a single directory
-* **[Site](render_engine/site.html)** - The container that helps to render all Pages and Collections in with uniform settigns and variables
+* **[Page](page.md)** - A single webpage item built from content, a template, raw data, or a combination of those things.
+* **[Collection](collection.md)** - A group of webpages built from the same template, organized in a single directory
+* **[Site](site.md)** - The container that helps to render all Pages and Collections in with uniform settigns and variables
 
 ## Installing Render Engine
 

--- a/docs/docs/page.md
+++ b/docs/docs/page.md
@@ -1,0 +1,1 @@
+::: render_engine.page

--- a/docs/docs/site.md
+++ b/docs/docs/site.md
@@ -1,0 +1,1 @@
+::: render_engine.site

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -14,3 +14,6 @@ markdown_extensions:
     permalink: True
   codehilite:
     guess_lang: False
+
+plugins:
+  - mkdocstrings

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -20,26 +20,37 @@ jinja2==3.1.2
     # via
     #   mkdocs
     #   mkdocs-material
+    #   mkdocstrings
     #   render-engine (pyproject.toml)
 markdown==3.3.7
     # via
     #   mkdocs
+    #   mkdocs-autorefs
     #   mkdocs-material
+    #   mkdocstrings
     #   pymdown-extensions
 markdown2==2.4.6
     # via render-engine (pyproject.toml)
 markupsafe==2.1.1
-    # via jinja2
+    # via
+    #   jinja2
+    #   mkdocstrings
 mergedeep==1.3.4
     # via mkdocs
 mkdocs==1.4.2
     # via
+    #   mkdocs-autorefs
     #   mkdocs-material
+    #   mkdocstrings
     #   render-engine (pyproject.toml)
+mkdocs-autorefs==0.4.1
+    # via mkdocstrings
 mkdocs-material==8.5.8
     # via render-engine (pyproject.toml)
 mkdocs-material-extensions==1.1
     # via mkdocs-material
+mkdocstrings==0.19.0
+    # via render-engine (pyproject.toml)
 more-itertools==9.0.0
     # via render-engine (pyproject.toml)
 packaging==21.3
@@ -51,7 +62,9 @@ pygments==2.13.0
     #   mkdocs-material
     #   rich
 pymdown-extensions==9.7
-    # via mkdocs-material
+    # via
+    #   mkdocs-material
+    #   mkdocstrings
 pyparsing==3.0.9
     # via packaging
 python-dateutil==2.8.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pytest", "pytest-cov"]
-docs = ["mkdocs", "mkdocs-material"]
+docs = ["mkdocs", "mkdocs-material", "mkdocstrings"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Add a new markdown document for each referenced object in the existing documentation. These documents use [mkdocstrings](https://mkdocstrings.github.io/) (a newly added documentation dependency) to generate autodoc-like documentation for the relevant Render Engine modules. Finally, resolve broken link warnings raised by `mkdocs build` by changing the links to match the ["Linking to pages" documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#linking-to-pages) from mkdocs.