### PR TITLE
Update mkdocstrings requirement

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -14,6 +14,8 @@ commonmark==0.9.1
     # via rich
 ghp-import==2.1.0
     # via mkdocs
+griffe==0.23.0
+    # via mkdocstrings-python
 idna==3.4
     # via requests
 jinja2==3.1.2
@@ -49,8 +51,12 @@ mkdocs-material==8.5.8
     # via render-engine (pyproject.toml)
 mkdocs-material-extensions==1.1
     # via mkdocs-material
-mkdocstrings==0.19.0
-    # via render-engine (pyproject.toml)
+mkdocstrings[python]==0.19.0
+    # via
+    #   mkdocstrings-python
+    #   render-engine (pyproject.toml)
+mkdocstrings-python==0.7.1
+    # via mkdocstrings
 more-itertools==9.0.0
     # via render-engine (pyproject.toml)
 packaging==21.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pytest", "pytest-cov"]
-docs = ["mkdocs", "mkdocs-material", "mkdocstrings"]
+docs = ["mkdocs", "mkdocs-material", "mkdocstrings[python]"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
PR #53 included the mkdocstrings requirement but accidentally omitted the python extras specifier, causing a docs build failure.