### PR TITLE
Handle undefined variables in rss templates

### DIFF
--- a/src/render_engine/render_engine_templates/rss2.0.xml
+++ b/src/render_engine/render_engine_templates/rss2.0.xml
@@ -6,13 +6,13 @@
     <description>{{description}}</description>
     <atom:link href="{{SITE_URL}}" rel="self" type="application/rss+xml" />
 
-{% if language %}<language>{{language}}</language>{% endif %}
-{% if copyright %}<copyright>{{copyright}}</copyright>{% endif %}
-{% if managing_editor %}<managingEditor>{{managing_editor}}</managingEditor>{% endif %}
-{% if web_master %}<webMaster>{{web_master}}</webMaster>{% endif %}
-{% if pub_date %}<pubDate>{{pub_date}}</pubDate>{% endif %}
-{% if last_build_date %}<lastBuildDate>{{last_build_date}}</lastBuildDate>{% endif %}
-{% if categories %}
+{% if language is defined and language %}<language>{{language}}</language>{% endif %}
+{% if copyright is defined and copyright %}<copyright>{{copyright}}</copyright>{% endif %}
+{% if managing_editor is defined and managing_editor %}<managingEditor>{{managing_editor}}</managingEditor>{% endif %}
+{% if web_master is defined and web_master %}<webMaster>{{web_master}}</webMaster>{% endif %}
+{% if pub_date is defined and pub_date %}<pubDate>{{pub_date}}</pubDate>{% endif %}
+{% if last_build_date is defined and last_build_date %}<lastBuildDate>{{last_build_date}}</lastBuildDate>{% endif %}
+{% if categories is defined and categories %}
 {% for category in categories %}
 {% if category['domain'] %}
 <category domain="{{category['domain']}}">{{category}}</category>
@@ -21,14 +21,14 @@
 {% endif %}
 {% endfor %}
 {% endif %}
-{% if generator %}<generator>{{generator}}</generator>{% endif %}
-{% if docs %}<docs>{{docs}}</docs>{% endif %}
-{% if cloud %}
+{% if generator is defined and generator %}<generator>{{generator}}</generator>{% endif %}
+{% if docs is defined and docs %}<docs>{{docs}}</docs>{% endif %}
+{% if cloud is defined and cloud %}
 <cloud domain="{{cloud.domain}}" port={{cloud.port}} path="{{cloud.path}}" registerProcedure="{{cloud.register_procedure}}" protocol="{{cloud.protocol}}" />
 {% endif %}
-{% if ttl %}<ttl>{{ttl}}</ttl>{% endif %}
-{% if image %}<image>{{image}}</image>{% endif %}
-{% if comments %}{{comments}}{% endif %}
+{% if ttl is defined and ttl %}<ttl>{{ttl}}</ttl>{% endif %}
+{% if image is defined and image %}<image>{{image}}</image>{% endif %}
+{% if comments is defined and comments %}{{comments}}{% endif %}
 {% for item in pages %}
 {% include 'rss2.0_items.xml' %}
 {% endfor %}

--- a/src/render_engine/render_engine_templates/rss2.0_items.xml
+++ b/src/render_engine/render_engine_templates/rss2.0_items.xml
@@ -1,16 +1,16 @@
 <item>
-{% if item.title %}<title>{{item.title}}</title>{% endif %}
-{% if item.description %}
+{% if item.title is defined and title %}<title>{{item.title}}</title>{% endif %}
+{% if item.description is defined and description %}
   <description><![CDATA[{{item.description}}]]></description>
 {% else %}
   <description><![CDATA[{{item._content|safe }}]]></description>
 {% endif %}
 
-{% if item.enclosure %}
+{% if item.enclosure is defined and enclosure %}
   <enclosure url="{{item.enclosure}}" length="{{item.enclosure.length}}" type="{{item.enclosure.mime_type}}" />
 {% endif %}
-{% if item.category %}
-  {% if item.category['domain'] %}
+{% if item.category is defined and category %}
+  {% if item.category is defined and category['domain'] %}
     <category domain="{{item.category['domain']}}">{{item.category}}</category>
   {% else %}
     <category>{{item.category}}</category>
@@ -19,9 +19,9 @@
     <link>
       {{SITE_URL}}{{item.url_for()}}
     </link>
-{% if item.date_published %}<pubDate>{{item.date_published | to_pub_date }}</pubDate>{% endif %}
-{% if item.guid %}<guid isPermaLink="false">{{item.guid}}</guid>{% endif %}
-{% if item.author %}{{item.author}}{% endif %}
-{% if item.comments %}{{item.comments}}{% endif %}
-{% if item.source %}<source url="{{item.source.url}}">{{item.source}}</source>{% endif %}
+{% if item.date_published is defined and date_published %}<pubDate>{{item.date_published | to_pub_date }}</pubDate>{% endif %}
+{% if item.guid is defined and guid %}<guid isPermaLink="false">{{item.guid}}</guid>{% endif %}
+{% if item.author is defined and author %}{{item.author}}{% endif %}
+{% if item.comments is defined and comments %}{{item.comments}}{% endif %}
+{% if item.source is defined and source %}<source url="{{item.source.url}}">{{item.source}}</source>{% endif %}
 </item>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+from jinja2 import Environment, select_autoescape
+import pytest
+
+from render_engine.engine import render_engine_templates_loader
+
+
+@pytest.fixture
+def engine() -> Environment:
+    return Environment(
+        loader=render_engine_templates_loader,
+        autoescape=select_autoescape(["xml"]),
+        lstrip_blocks=True,
+        trim_blocks=True,
+    )

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -1,5 +1,7 @@
 import pluggy
 
+from jinja2 import StrictUndefined
+
 from render_engine.collection import Collection
 from render_engine.feeds import RSSFeed
 from render_engine.page import Page
@@ -65,3 +67,26 @@ def test_rss_feed_item_url(tmp_path):
     collection = TestCollection()
     print(collection._feed.template)
     assert "http://localhost:8000//page.html" in collection._feed._render_content(engine=engine)
+
+
+def test_rss_feed_template_with_strictundefined(engine, tmp_path):
+    """Test that the RSS feed template works with the StrictUndefined undefined handler."""
+    tmp_dir = tmp_path / "content"
+    tmp_dir.mkdir()
+    file = tmp_dir / "#"
+    file.write_text("test")
+
+    class TestCollection(Collection):
+        pages = [Page(content_path=file)]
+        Feed = RSSFeed
+
+    collection = TestCollection()
+    engine.undefined = StrictUndefined
+    rendered_content = collection._feed._render_content(
+        engine=engine,
+        SITE_TITLE="Test Site Title",
+        SITE_URL="http://localhost:8000",
+        title="Test Feed Title",
+        description="Test Feed Description",
+    )
+    assert "http://localhost:8000/page.html" in rendered_content


### PR DESCRIPTION
These templates used to work when using the StrictUndefined undefined behavior in the jinja2 environment, but in recent releases, this causes the build to fail. This issue can be seen at
https://github.com/Python-Community-News/Site/pull/38. Using the `is defined` test results in similar behavior even when `StrictUndefined` is set, allowing site developers to catch typos or other missing template context without breaking their rss feeds.

This change also includes a new test and a test fixture to create a jinja2 environment that can be modified with the scope of a single test.