### PR TITLE
Revert "Bump markdown from 3.3.7 to 3.4.3"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ jinja2==3.1.2
     #   mkdocs-material
     #   mkdocstrings
     #   render-engine (pyproject.toml)
-markdown==3.4.3
+markdown==3.3.7
     # via
     #   mkdocs
     #   mkdocs-autorefs


### PR DESCRIPTION
Reverts kjaymiller/render_engine#138

mkdocstings still requires markdown 3.3.7.

