### PR TITLE
add dependabot ignore for Markdown 3.4.X

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     directory: "/"
     ignore:
       - dependency-name: "Markdown"
-      # For Markdown, ignore all updates for version 4 and 5
+      # For Markdown, ignore all updates for version 3.4.X
         versions: ["3.4.x"]
     # Check the pypi registry for updates every day (weekdays)
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,11 @@ updates:
   - package-ecosystem: "pip"
     # Look for `package.json` and `lock` files in the `root` directory
     directory: "/"
-    # Check the npm registry for updates every day (weekdays)
+    ignore:
+      - dependency-name: "Markdown"
+      # For Markdown, ignore all updates for version 4 and 5
+        versions: ["3.4.x"]
+    # Check the pypi registry for updates every day (weekdays)
     schedule:
       interval: "daily"
 


### PR DESCRIPTION
Currently we are using mkdocs as a documentation framework. mkdocs has pinned the `Markdown` dependency to 3.3.X as to not potentially break extensions.

In the future we will no be using mkdocs in favor for render_engine building it's own documentation.

render_engine uses  markdown2 so in the future Markdown will not be a dependency.