### PR TITLE
2023.4.2a1-dates-conversion

### DIFF
--- a/src/render_engine/archive.py
+++ b/src/render_engine/archive.py
@@ -2,9 +2,10 @@
 The Archive is the Page object used by the collection that focuses on presenting Page objects.
 """
 import pathlib
+
 import jinja2
 
-from .page import BasePage 
+from .page import BasePage
 
 
 class Archive(BasePage):
@@ -15,7 +16,7 @@ class Archive(BasePage):
         Attributes can be used to customize the 
         [archive_template][src.render_engine.collection.Collection].
 
-    Custom [`Page`][src.render_engine.page.Page] object used to show all the pages in a [Collection][src.render_engine.Collection].
+    Custom [`Page`][src.render_engine.page.Page] used to show the pages in a [Collection][src.render_engine.Collection].
 
     Parameters:
         pages: The list of pages to include in the archive

--- a/src/render_engine/blog.py
+++ b/src/render_engine/blog.py
@@ -1,10 +1,3 @@
-import datetime
-import logging
-import typing
-
-import dateutil.parser
-import more_itertools
-
 from .collection import Collection
 from .feeds import RSSFeed
 from .page import Page
@@ -13,9 +6,9 @@ from .parsers.markdown import MarkdownPageParser
 
 class BlogPost(Page):
     """Page Like object with slight modifications to work with BlogPosts."""
-
     list_attrs = ["tags"]
     invalid_attrs = ["slug"]
+
 
 class Blog(Collection):
     """
@@ -27,7 +20,7 @@ class Blog(Collection):
     """
 
     BasePageParser = MarkdownPageParser
-    content_type: typing.Type[BlogPost] = BlogPost
+    content_type: BlogPost = BlogPost
     sort_reverse: bool = True
     sort_by = "date"
     has_archive = True

--- a/src/render_engine/blog.py
+++ b/src/render_engine/blog.py
@@ -12,7 +12,7 @@ class BlogPost(Page):
 
 class Blog(Collection):
     """
-    Custom :py:class:`collection.Collection` class with archiving enabled, sort by `date_published` by default.
+    Custom :py:class:`collection.Collection` class with archiving enabled, sort by `date` by default.
 
     Todos:
         - Add Support for JSON Feeds

--- a/src/render_engine/blog.py
+++ b/src/render_engine/blog.py
@@ -11,58 +11,11 @@ from .page import Page
 from .parsers.markdown import MarkdownPageParser
 
 
-def _check_date_values(date_value_name:str, potential_attrs: typing.Iterable[str]) -> datetime.date | datetime.datetime:
-    """
-    Checks potential attrs for a date value.
-    This will raise an error if the value is not a datetime object.
-    """
-    
-    set_attr = more_itertools.first_true(potential_attrs)
-
-    if set_attr is None:
-        raise ValueError(
-            f"""Error Parsing {date_value_name}. No date value found."""
-        )
-
-    if isinstance(set_attr, datetime.datetime) or isinstance(set_attr, datetime.date):
-        return set_attr.replace(tzinfo=None)
-        
-    else:
-        logging.warning(
-                f"""
-                date_modified={set_attr} equated as string and not datetime.
-                Render Engine will attempt to parse as a datetime object. For Best Results use RFC2822 format.
-                
-                For more information, see: https://render-engine.readthedocs.io/en/latest/blog.html#date-published-and-date-modified
-                """
-        )
-        return dateutil.parser.parse(set_attr).replace(tzinfo=None)
-
-
 class BlogPost(Page):
     """Page Like object with slight modifications to work with BlogPosts."""
 
     list_attrs = ["tags"]
-    invalid_attrs = ["slug", "date_published", "date_modified"]
-
-    @property
-    def date_modified(self):
-        valid_date_modified_values = (
-                getattr(self, "_date_modified", None),
-                getattr(self, "modified_date", None),
-                getattr(self, "date", None),
-            )
-        return _check_date_values("date_modified", valid_date_modified_values)
-
-    @property
-    def date_published(self):
-        valid_date_published_values = (
-                getattr(self, "_date_published", None),
-                getattr(self, "publish_date", None),
-                getattr(self, "date", None),
-            )
-    
-        return _check_date_values("date_published", valid_date_published_values)
+    invalid_attrs = ["slug"]
 
 class Blog(Collection):
     """
@@ -76,6 +29,6 @@ class Blog(Collection):
     BasePageParser = MarkdownPageParser
     content_type: typing.Type[BlogPost] = BlogPost
     sort_reverse: bool = True
-    sort_by = "date_published"
+    sort_by = "date"
     has_archive = True
     Feed = RSSFeed

--- a/src/render_engine/collection.py
+++ b/src/render_engine/collection.py
@@ -1,6 +1,5 @@
-from enum import Enum
 import pathlib
-from typing import Any, Callable, Generator, Type
+import typing
 
 import git
 from more_itertools import batched, flatten
@@ -9,10 +8,10 @@ from slugify import slugify
 from ._base_object import BaseObject
 from .archive import Archive
 from .feeds import RSSFeed
+from .hookspecs import register_plugins
 from .page import Page
 from .parsers import BasePageParser
 from .parsers.markdown import MarkdownPageParser
-from .hookspecs import register_plugins
 
 
 class Collection(BaseObject):
@@ -57,22 +56,22 @@ class Collection(BaseObject):
 
     archive_template: str | None
     content_path: pathlib.Path | str
-    content_type: Type[Page] = Page
-    Feed: Type[RSSFeed]
+    content_type: Page = Page
+    Feed: RSSFeed
     feed_title: str
     include_suffixes: list[str] = ["*.md", "*.html"]
     items_per_page: int | None
-    PageParser: Type[BasePageParser] = MarkdownPageParser
-    parser_extras: dict[str, Any]
+    PageParser: BasePageParser = MarkdownPageParser
+    parser_extras: dict[str, any]
     routes: list[str] = ["./"]
     sort_by: str = "title"
     sort_reverse: bool = False
     template: str | None
-    plugins: list[Callable] | None
+    plugins: list[typing.Callable] | None
 
     def __init__(
         self,
-        plugins: list[Callable] = [],
+        plugins: list[typing.Callable] = [],
     ) -> None:
 
         self.has_archive = any(
@@ -95,7 +94,7 @@ class Collection(BaseObject):
             ]
         )
     
-    def _generate_content_from_modified_pages(self) -> Generator[Page, None, None]:
+    def _generate_content_from_modified_pages(self) -> typing.Generator[Page, None, None]:
         """
         Check git status for newly created and modified files.
         Returns the Page objects for the files in the content path
@@ -139,7 +138,7 @@ class Collection(BaseObject):
         )
 
     @property
-    def archives(self) -> Generator[Archive, None, None]:
+    def archives(self) -> typing.Generator[Archive, None, None]:
         """
         Returns a [Archive][src.render_engine.archive] objects containing the pages from the `content_path` .
 

--- a/src/render_engine/engine.py
+++ b/src/render_engine/engine.py
@@ -1,14 +1,14 @@
 from datetime import datetime
 from email import utils
-from typing import Type
+import typing
 
 from jinja2 import (
     ChoiceLoader,
     Environment,
     FileSystemLoader,
     PackageLoader,
-    select_autoescape,
     pass_environment,
+    select_autoescape,
 )
 
 render_engine_templates_loader = ChoiceLoader(
@@ -26,7 +26,7 @@ def to_pub_date(value: datetime):
     return utils.format_datetime(value)
 
 @pass_environment
-def format_datetime(env, value: str) -> datetime:
+def format_datetime(env: Environment, value: str) -> datetime:
     """
     Parse information from the given class object.
     """

--- a/src/render_engine/engine.py
+++ b/src/render_engine/engine.py
@@ -8,6 +8,7 @@ from jinja2 import (
     FileSystemLoader,
     PackageLoader,
     select_autoescape,
+    pass_environment,
 )
 
 render_engine_templates_loader = ChoiceLoader(
@@ -23,6 +24,13 @@ def to_pub_date(value: datetime):
     Parse information from the given class object.
     """
     return utils.format_datetime(value)
+
+@pass_environment
+def format_datetime(env, value: str) -> datetime:
+    """
+    Parse information from the given class object.
+    """
+    return datetime.strftime(value, env.globals.get("DATETIME_FORMAT", "%d %b %Y %H:%M %Z"))
 
 
 def url_for(value: str, site):
@@ -40,3 +48,4 @@ engine = Environment(
 )
 
 engine.filters["to_pub_date"] = to_pub_date
+engine.filters["format_datetime"] = format_datetime

--- a/src/render_engine/render_engine_templates/rss2.0_items.xml
+++ b/src/render_engine/render_engine_templates/rss2.0_items.xml
@@ -19,7 +19,7 @@
     <link>
       {{SITE_URL}}{{item.url_for()}}
     </link>
-{% if item.date_published is defined and date_published %}<pubDate>{{item.date_published | to_pub_date }}</pubDate>{% endif %}
+{% if item.date is defined %}<pubDate>{{item.date | to_pub_date }}</pubDate>{% endif %}
 {% if item.guid is defined and guid %}<guid isPermaLink="false">{{item.guid}}</guid>{% endif %}
 {% if item.author is defined and author %}{{item.author}}{% endif %}
 {% if item.comments is defined and comments %}{{item.comments}}{% endif %}

--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -11,6 +11,7 @@ from .collection import Collection
 from .engine import engine, url_for
 from .hookspecs import register_plugins
 from .page import Page
+from datetime import datetime
 
 
 class Site:
@@ -35,8 +36,11 @@ class Site:
     site_vars: dict = {
         "SITE_TITLE": "Untitled Site",
         "SITE_URL": "http://localhost:8000/",
+        "DATETIME_FORMAT": "%d %b %Y %H:%M %Z"
     }
     plugins: list
+
+
 
     def __init__(
         self,

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -1,42 +1,7 @@
-import datetime
-import pytest
-
-from render_engine.blog import (
-    Blog,
-    BlogPost,
-    _check_date_values,
-)
+from render_engine.blog import Blog
 
 
 def test_blog_has_feed():
+    """Tests that the Blog class has a Feed attribute."""
     blog = Blog()
     assert hasattr(blog, "Feed")
-
-def test_blog_post_datetime_parses_common_US_formats(date_attr: str):
-    """
-    Test that the date_published matches the expected common dates.
-    # TODO: test for other localizations
-    """
-
-    class CustomBlogPost(BlogPost):
-        def __init__(self):
-            super().__init__()
-            setattr(self, f"_{date_attr}", "2020-01-01")
-        
-    blog = CustomBlogPost()
-    assert getattr(blog, date_attr, datetime.date(2020,1,1))
-
-def test_blog_post_datetime_compares_as_naive():
-    """Test that the datetime objects are naive."""
-
-    class CustomBlogPost1(BlogPost):
-        date: datetime.datetime = datetime.datetime(2020, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    
-    class CustomBlogPost2(BlogPost):
-        date: datetime.datetime = datetime.datetime(2019, 1, 1, 0, 0, 0)    
-    
-    class CustomBlog(Blog):
-        pages = [CustomBlogPost1(), CustomBlogPost2()]
-
-    blog = CustomBlog()
-    assert blog.pages[0].date_published > blog.pages[1].date_published

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -12,36 +12,6 @@ def test_blog_has_feed():
     blog = Blog()
     assert hasattr(blog, "Feed")
 
-@pytest.mark.parametrize(
-    "date_key",
-    [
-        ("date"),
-        ("_date_published"),
-        ("publish_date"),
-    ]
- )
-def test_blog_date_published_found_in_expected_parameters(date_key: str):
-    class CustomBlogPost(BlogPost):
-        def __init__(self, **kwargs):
-            super().__init__(**kwargs)
-            setattr(self, date_key, "2020-01-01")
-
-    blog = CustomBlogPost()
-
-    assert blog.date_published == datetime.datetime(2020, 1, 1,0,0,0)
-
-
-def test__check_date_values_raises_error_if_no_date_value_found():
-    with pytest.raises(ValueError):
-        _check_date_values("test_date_value", (None, None, None))
-        
-@pytest.mark.parametrize(
-    "date_attr",
-    [
-        ("date_modified"),
-        ("date_published"),
-    ]
-)
 def test_blog_post_datetime_parses_common_US_formats(date_attr: str):
     """
     Test that the date_published matches the expected common dates.

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -1,11 +1,12 @@
-import pluggy
+import datetime
 
+import pluggy
 from jinja2 import StrictUndefined
 
 from render_engine.collection import Collection
+from render_engine.engine import engine
 from render_engine.feeds import RSSFeed
 from render_engine.page import Page
-from render_engine.engine import engine
 
 pm = pluggy.PluginManager("fake_test")
 
@@ -90,3 +91,22 @@ def test_rss_feed_template_with_strictundefined(engine, tmp_path):
         description="Test Feed Description",
     )
     assert "http://localhost:8000/page.html" in rendered_content
+
+
+def test_rss_feed_template_parses_date_correctly(engine):
+    """Tests that a feed parses the page date in RFC3339 Format"""
+    class TestPage(Page):
+        date = datetime.datetime(2021, 1, 1, 0, 0, 0, tzinfo=datetime.UTC)
+    class TestCollection(Collection):
+        Feed = RSSFeed
+        pages = [TestPage()]
+
+    collection = TestCollection()
+    rendered_content = collection._feed._render_content(
+        engine=engine,
+        SITE_TITLE="Test Site Title",
+        SITE_URL="http://localhost:8000",
+        title="Test Feed Title",
+        description="Test Feed Description",
+    )
+    assert "2021-01-01T00:00:00+00:00" in rendered_content

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -4,7 +4,7 @@ import pluggy
 from jinja2 import StrictUndefined
 
 from render_engine.collection import Collection
-from render_engine.engine import engine
+from render_engine.engine import engine, to_pub_date
 from render_engine.feeds import RSSFeed
 from render_engine.page import Page
 
@@ -94,14 +94,19 @@ def test_rss_feed_template_with_strictundefined(engine, tmp_path):
 
 
 def test_rss_feed_template_parses_date_correctly(engine):
-    """Tests that a feed parses the page date in RFC3339 Format"""
+    """Tests that a feed parses the page date in RFC2822 Format"""
+
+
     class TestPage(Page):
-        date = datetime.datetime(2021, 1, 1, 0, 0, 0, tzinfo=datetime.UTC)
+        date = datetime.datetime(2023, 4, 15, 0, 0, 0, tzinfo=datetime.timezone.utc)   # noqa: UP017
     class TestCollection(Collection):
         Feed = RSSFeed
         pages = [TestPage()]
 
     collection = TestCollection()
+
+    engine.filters["to_pub_date"] = to_pub_date
+
     rendered_content = collection._feed._render_content(
         engine=engine,
         SITE_TITLE="Test Site Title",
@@ -109,4 +114,5 @@ def test_rss_feed_template_parses_date_correctly(engine):
         title="Test Feed Title",
         description="Test Feed Description",
     )
-    assert "2021-01-01T00:00:00+00:00" in rendered_content
+
+    assert "Sat, 15 Apr 2023 00:00:00 +0000" in rendered_content


### PR DESCRIPTION
Fully removes references to `date_published`/`date_modified` in favor of a single `date` value that blog is concerned about. 