### PR TITLE
change dependabot to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
         versions: ["3.4.x"]
     # Check the pypi registry for updates every day (weekdays)
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   - package-ecosystem: "github-actions"
     # Workflow files stored in the


### PR DESCRIPTION
Fixes #168

## Summary

Moves pip interval to weekly

## Type of Issue

- [ ] :bug: (bug)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)

