### PR TITLE
Makes many functions private

### DIFF
--- a/docs/docs/site.md
+++ b/docs/docs/site.md
@@ -1,5 +1,1 @@
-::: render_engine.site
-
-### `output_path`
-
-The `output_path` is the path to the folder where your rendered site will be served. This is the folder that will contain HTML, CSS, and Javascript.
+::: src.render_engine.site.Site

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -49,7 +49,7 @@ def test_site_page_in_route_list(tmp_path):
     site = Site()
 
     # assert that the route list is empty
-    assert len(site.route_list) == 0
+    assert len(site._route_list) == 0
 
     class CustomPage(Page):
         test_value = "test"
@@ -57,7 +57,7 @@ def test_site_page_in_route_list(tmp_path):
 
     site.page(CustomPage)
 
-    assert site.route_list["custompage"].test_value == "test"
+    assert site._route_list["custompage"].test_value == "test"
 
 
 def test_site_collection_in_route_list():
@@ -65,7 +65,7 @@ def test_site_collection_in_route_list():
     site = Site()
 
     # assert that the route list is empty
-    assert len(site.route_list) == 0
+    assert len(site._route_list) == 0
 
     class CustomPage(Page):
         test_value = "test"
@@ -75,8 +75,8 @@ def test_site_collection_in_route_list():
 
     collection = site.collection(collection)
 
-    assert site.route_list["collection"] == collection
-    assert len(site.route_list) == 1
+    assert site._route_list["collection"] == collection
+    assert len(site._route_list) == 1
 
 
 def test_site_page_with_multiple_routes_has_one_entry_in_routes_list():
@@ -88,7 +88,7 @@ def test_site_page_with_multiple_routes_has_one_entry_in_routes_list():
 
     site.page(CustomPage)
 
-    assert len(site.route_list) == 1
+    assert len(site._route_list) == 1
 
 
 def test_site_output_path(tmp_path):


### PR DESCRIPTION
## Summary

changes many of the methods in Site to private methods. This removes them from documentation as these are meant to be used internally and not by users or plugin developers.

## Type of Issue

- [X] :bug: (bug)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)

## Issues Referenced

resolves #87

## Discussions Referenced

address <#DISCUSSION NUMBER>

## Next Steps

Check Collection and Page for the same issues.