### PR TITLE
set rss <atom:link> to link to rss link

### DIFF
--- a/src/render_engine/_base_object.py
+++ b/src/render_engine/_base_object.py
@@ -68,6 +68,7 @@ class BaseObject:
             "title": self._title,
             "slug": self._slug,
             "url": self.url_for(),
+            "path_name": self.path_name,
         }
 
         # Pull out template_vars

--- a/src/render_engine/feeds.py
+++ b/src/render_engine/feeds.py
@@ -12,12 +12,14 @@ class RSSFeed(BasePage):
     Creates an RSS feed [`Page`][render_engine.Page] Object.
 
     !!! Note
-        This is the base object type and should only contain the params identified by the standards defined in the [RSS 2.0 Specification](http://www.rssboard.org/rss-specification)
+        This is the base object type and should only contain the params identified
+        by the standards defined in the [RSS 2.0 Specification](http://www.rssboard.org/rss-specification)
 
     This is built using the built-in `rss2.0.xml` jinja template.
 
     !!! Note
-        Some browsers may not support the `rss` extension. If you are having issues with your feed, try changing the extension to `xml`.
+        Some browsers may not support the `rss` extension.
+        If you are having issues with your feed, try changing the extension to `xml`.
 
         ```python
         from render_engine import Site, RSSFeed

--- a/src/render_engine/render_engine_templates/rss2.0.xml
+++ b/src/render_engine/render_engine_templates/rss2.0.xml
@@ -4,7 +4,7 @@
     <title>{{SITE_TITLE}}-{{title}}</title>
     <link>{{SITE_URL}}</link>
     <description>{{description}}</description>
-    <atom:link href="{{SITE_URL}}" rel="self" type="application/rss+xml" />
+    <atom:link href="{{SITE_URL}}/{{ path_name }}" rel="self" type="application/rss+xml" />
 
 {% if language is defined and language %}<language>{{language}}</language>{% endif %}
 {% if copyright is defined and copyright %}<copyright>{{copyright}}</copyright>{% endif %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,11 +35,31 @@ def site(tmp_path):
     file = tmp_dir / "#"
     file.write_text("test")
     
+    site = Site()
 
+    @site.collection
     class TestCollection(Collection):
         pages = [Page(content_path=file)]
         Feed = RSSFeed
 
-    site = Site()
-    site.collection(TestCollection)
     return site
+
+
+@pytest.fixture()
+def feed_test_site(tmp_path):
+    tmp_dir = tmp_path / "content"
+    tmp_dir.mkdir()
+    file = tmp_dir / "#"
+    file.write_text("test")
+    
+    site = Site()
+
+    @site.collection
+    class TestCollection(Collection):
+        pages = [Page(content_path=file)]
+        Feed = RSSFeed
+        routes = ['feed']
+
+    feed = site.route_list['testcollection'].feed
+    feed_content = feed._render_content(engine=site.engine, SITE_URL="http://localhost:8000")
+    return feed_content

--- a/tests/test_base_object.py
+++ b/tests/test_base_object.py
@@ -49,6 +49,7 @@ class TestBaseObjectProperties:
             "title": "TestObject",
             "slug": "testobject",
             "url": None,
+            "path_name": "testobject.html",
         }
 
     def test_base_object_to_dict_with_template_vars(self):
@@ -61,6 +62,7 @@ class TestBaseObjectProperties:
             "url": None,
             "test": "test",
             'template_vars': {'test': 'test'},
+            "path_name": "testobject.html",
         }
 
         assert self.test_object.template_vars == {"test": "test"}

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -7,6 +7,7 @@ from jinja2 import StrictUndefined
 from render_engine.collection import Collection
 from render_engine.feeds import RSSFeed
 from render_engine.page import Page
+from render_engine.site import Site
 
 pm = pluggy.PluginManager("fake_test")
 
@@ -29,41 +30,23 @@ def test_feed_path_name():
 
     assert feed().path_name == "feed.rss"
 
-def test_rss_feed_title_from_collection():
-    """Test that the feed title is set from the collection"""
+def test_rss_feed_title_from_collection(feed_test_site):
+    """
+    Test a Collection's title is used as the feed title if no title is provided.
 
-    class TestCollection(Collection):
-        feed_title = "Test Feed Title"
-        Feed = RSSFeed
-        pages = [Page()]
+    In this case, the collection is named TestCollection.
+    """
+    assert "<title>Untitled Site-TestCollection</title>" in feed_test_site
 
-    collection = TestCollection()
-
-    assert collection.feed.title == "Test Feed Title"
-
-
-def test_rss_feed_inherites_from_collection():
-    """Test that the feed title is set from the collection"""
-
-    class BasicCollection(Collection):
-        pages = [Page()]
-        archive_template = None
-        Feed = RSSFeed
-
-    collection = BasicCollection()
-
-    assert collection.feed.title == "BasicCollection"
-
-
-def test_rss_feed_item_url(site):
+def test_rss_feed_item_url(feed_test_site):
     """Test that the feed item url is set correctly"""
-    assert "<link>http://localhost:8000/page.html</link>" in site.route_list['testcollection'].feed._render_content(engine=site.engine, SITE_URL="http://localhost:8000")
+    assert "<link>http://localhost:8000/page.html</link>" in feed_test_site
 
 
 
-def test_rss_feed_item_has_guid(site):
+def test_rss_feed_item_has_guid(feed_test_site):
     """Test that the feed item url is set correctly"""
-    assert '<guid isPermaLink="true">http://localhost:8000/page.html</guid>' in site.route_list['testcollection'].feed._render_content(engine=site.engine, SITE_URL="http://localhost:8000")
+    assert '<guid isPermaLink="true">http://localhost:8000/page.html</guid>' in feed_test_site
 
 
 @pytest.mark.skip("Invalid Test")
@@ -93,7 +76,6 @@ def test_rss_feed_template_with_strictundefined(engine, tmp_path):
 def test_rss_feed_template_parses_date_correctly(engine):
     """Tests that a feed parses the page date in RFC2822 Format"""
 
-
     class TestPage(Page):
         date = datetime.datetime(2023, 4, 15, 0, 0, 0, tzinfo=datetime.timezone.utc)   # noqa: UP017
     class TestCollection(Collection):
@@ -111,3 +93,7 @@ def test_rss_feed_template_parses_date_correctly(engine):
     )
 
     assert "Sat, 15 Apr 2023 00:00:00 +0000" in rendered_content
+
+def test_feed_atom_link(feed_test_site):
+    """Test that the feed atom link is set correctly"""
+    assert '<atom:link href="http://localhost:8000/testcollection.rss" rel="self" type="application/rss+xml" />' in feed_test_site


### PR DESCRIPTION
## Summary

changes:
- adds `Page.path_name` to `Page.to_dict()`
- changes atom:link to `<SITE_URL>/<path_name>`

build steps:
- [ ] Documentation
- [x] Testing
## Type of Issue

- [x] :bug: (bug)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)

## Issues Referenced

resolves #171

## Discussions Referenced

address <#DISCUSSION NUMBER>

## Next Steps

<ANY FURTHER STEPS TO BE TAKEN>
