### PR TITLE
uses path_file | to absolute

### DIFF
--- a/src/render_engine/render_engine_templates/rss2.0.xml
+++ b/src/render_engine/render_engine_templates/rss2.0.xml
@@ -4,7 +4,7 @@
     <title>{{SITE_TITLE}}-{{title}}</title>
     <link>{{SITE_URL}}</link>
     <description>{{description}}</description>
-    <atom:link href="{{SITE_URL}}/{{ path_name }}" rel="self" type="application/rss+xml" />
+    <atom:link href="{{ path_name | to_absolute }}" rel="self" type="application/rss+xml" />
 
 {% if language is defined and language %}<language>{{language}}</language>{% endif %}
 {% if copyright is defined and copyright %}<copyright>{{copyright}}</copyright>{% endif %}


### PR DESCRIPTION
## Summary

Uses the {{path_name | to_absolute}} instead of combining SITE_URL/PATH_NAME

## Type of Issue

- [ ] :bug: (bug)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)

## Issues Referenced

resolves <#ISSUE NUMBER>

## Discussions Referenced

address <#DISCUSSION NUMBER>

## Next Steps

<ANY FURTHER STEPS TO BE TAKEN>
