### PR TITLE
Build now creates a `__version__.py` that can be used to programmatically see the RE version. Rendering the site displays the RE version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,5 @@ untitled-site/
 
 .DS_Store
 .python-version
+
+__version__.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,9 +42,9 @@ dev = [
   "watchfiles",
 ]
 
-
 [tool.setuptools_scm]
 local_scheme = "no-local-version"
+version_file = "src/render_engine/__version__.py"
 # version_scheme = "python-simplified-semver"
 
 [project.urls]

--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -3,6 +3,7 @@ import logging
 from collections import defaultdict
 from pathlib import Path
 
+import rich
 from jinja2 import FileSystemLoader, PrefixLoader
 from rich.progress import Progress
 
@@ -12,6 +13,12 @@ from .page import Page
 from .plugins import PluginManager, handle_plugin_registration
 from .site_map import SiteMap
 from .themes import Theme, ThemeManager
+
+try:
+    # Get the RE version for display. If it's not set it means we're working locally.
+    from render_engine.__version__ import __version__ as re_version
+except ImportError:
+    re_version = "development"
 
 
 class Site:
@@ -251,7 +258,10 @@ class Site:
         You can choose to call it manually in your file or
         use the CLI command [`render-engine build`][src.render_engine.cli.build]
         """
-
+        rich.print(
+            f"[green]Building {repr(self.site_vars.get('SITE_TITLE', 'your site'))} "
+            f"with Render Engine version {re_version}"
+        )
         with Progress() as progress:
             task_site_map = progress.add_task("Generating site map", total=1)
             self._site_map = SiteMap(self.route_list, self.site_vars.get("SITE_URL", ""))


### PR DESCRIPTION
Resolves #1001

#### Type of Issue

- [ ] :bug: (bug)
- [ ] :book: (Documentation)
- [X] :arrow_up: (Update)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

N/A

- [ ] YES - Changes have been documented

#### Changes have been Tested

- [X] YES - Changes have been tested

#### Next Steps

