### PR TITLE
Store the metadata as an attribute of a `Page` for easy retrieval.

### DIFF
--- a/src/render_engine/_base_object.py
+++ b/src/render_engine/_base_object.py
@@ -27,6 +27,7 @@ class BaseObject:
     plugins: list[Callable] | None
     plugin_settings: dict = {"plugins": defaultdict(dict)}
     skip_site_map: bool = False
+    metadata: dict = dict()
 
     @property
     def _title(self) -> str:

--- a/src/render_engine/page.py
+++ b/src/render_engine/page.py
@@ -204,10 +204,10 @@ class Page(BasePage):
 
     content: Any
     content_path: Path | str | None
-    Parser: type[BasePageParser] = BasePageParser
     inherit_plugins: bool
     parser_extras: dict[str, Any] | None
     title: str
+    Parser: type[BasePageParser] = BasePageParser
 
     def __init__(
         self,
@@ -229,17 +229,17 @@ class Page(BasePage):
 
         # Parse Content from the Content Path or the Content
         if content_path := (content_path or getattr(self, "content_path", None)):
-            attrs, self.content = self.Parser.parse_content_path(content_path)
+            self.metadata, self.content = self.Parser.parse_content_path(content_path)
 
         elif content := (content or getattr(self, "content", None)):
-            attrs, self.content = self.Parser.parse_content(content)
+            self.metadata, self.content = self.Parser.parse_content(content)
 
         else:
-            attrs = {}
+            self.metadata = {}
             self.content = None
 
         # Set the attributes
-        for key, val in attrs.items():
+        for key, val in self.metadata.items():
             setattr(self, key.lower(), val)
 
     @property


### PR DESCRIPTION
Stores the `Page` metadata as an attribute of the object.

#### Type of Issue

- [ ] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [X] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [ ] YES - Changes have been documented

#### Changes have been Tested

- [X] YES - Changes have been tested

#### Next Steps

This is a required step for #1011
