### PR TITLE
add 3.14 to noxfile

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,6 @@
 import nox
 
-PYTHON_VERSIONS = ["3.13", "3.12", "3.11", "3.10"]
+PYTHON_VERSIONS = ["3.14", "3.13", "3.12", "3.11", "3.10"]
 
 
 @nox.session


### PR DESCRIPTION
adds '3.14' to `python_versions` in noxfile

resolves: #1040
