### PR TITLE
Justfile modifications

### DIFF
--- a/justfile
+++ b/justfile
@@ -57,7 +57,7 @@ mypy:
     -uvx mypy src # For the moment we have way too many issues in mypy so not having it fail.
 
 # Generate coverage badge
-badge: (test '--cov-report=xml')
+badge: (test-cov-report 'xml')
     uvx --with "genbadge[coverage]" genbadge coverage -i coverage.xml
 
 # Run full CI workflow (sync, lint, test, badge)


### PR DESCRIPTION
Resolves #1054 

- Adds ability to test with arbitrary Python versions `just pytest <version> <flags>`
- Modifies `test` to be able to set multiple flags and not just one.
- Fix description for `test-cov-report`
- Modify badge to explicitly call `test-cov-report` with `xml`
- Add consistency for lint/format:
  - `lint`/`format` do not fix issues
  - `lint-fix`/`format-fix` do fix issues.
  - `ruff` does not attempt to fix
  - Added `ruff-fix` that will fix lint and formatting issues (NOTE - this does not use recipe dependency in order to not fail for something the linter can't fix but the formatter does. After fixing with the linter and the formatter, the linter is run again without fixing to ensure that everything has been addressed.)
- Ignore errors for the `mypy` recipe because we have _so many_ mypy errors that it is causing the `ci` recipe to break.
- Remove `test` dependency from `ci` as it was redundant (with `nox` and `badge` this would be an additional time running the tests.)

#### Type of Issue

- [ ] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [X] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [ ] YES - Changes have been documented

Documentation will need to be done when #1053 is merged or in that PR if this is merged first.

#### Changes have been Tested

- [X] YES - Changes have been tested

#### Next Steps

Update documentation 
