### PR TITLE
Have `Site` initialize a `SiteMap` and update during `render`.

### DIFF
--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -76,7 +76,7 @@ class Site:
         self.subcollections: dict[str, list] = {"pages": []}
         self.theme_manager.engine.globals.update(self.site_vars)
         self.theme_manager.add_loader(0, FileSystemLoader(self._template_path))
-        self._site_map = None
+        self._site_map = SiteMap()
 
     @property
     def output_path(self) -> Path | str:
@@ -239,7 +239,7 @@ class Site:
     def template_path(self, template_path: str) -> None:
         self.theme_manager.add_loader(0, FileSystemLoader(template_path))
 
-    def render(self) -> None:
+    def render(self, site_url: str | None = None) -> None:
         """
         Render all pages and collections.
 
@@ -251,14 +251,23 @@ class Site:
 
         You can choose to call it manually in your file or
         use the CLI command [`render-engine build`][src.render_engine.cli.build]
+
+        :param site_url: Alternate URL for the site to use in the site map
         """
         rich.print(
             f"[green]Building {repr(self.site_vars.get('SITE_TITLE', 'your site'))} "
             f"with Render Engine version {re_version}"
         )
         with Progress() as progress:
-            task_site_map = progress.add_task("Generating site map", total=1)
-            self._site_map = SiteMap(self.route_list, self.site_vars.get("SITE_URL", ""))
+            site_url = site_url if site_url is not None else self.site_vars.get("SITE_URL", "")
+            task_site_map = progress.add_task(f"Updating site map. {site_url=}", total=1)
+
+            # self._site_map will be initialized with an empty route list and the site URL pointing
+            # to https://localhost:8000/ This task will update to the correct site URL and with the route list
+            # as it will be rendered.
+            self._site_map.site_url = site_url
+            self._site_map.update(self.route_list)
+
             if self.render_html_site_map:
 
                 @self.page

--- a/src/render_engine/site_map.py
+++ b/src/render_engine/site_map.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable
+from collections.abc import Generator, Iterable
 from pathlib import Path
 from urllib.parse import urljoin
 
@@ -43,17 +43,37 @@ class SiteMapEntry:
 class SiteMap:
     """Site map"""
 
-    def __init__(self, route_list: dict, site_url: str):
+    def __init__(self, site_url: str = "", route_list: dict | None = None) -> None:
         """
         Create the site map based on the route_list
 
-        :param route_list: The route list to parse
         :param site_url: Used for rendering the HTML to have absolute URLs.
+        :param route_list: The route list to parse
         """
         self._route_map = dict()
         self._collections = dict()
+        self._site_url = site_url
+        if not route_list:
+            return
+        self.update(route_list)
+
+    @property
+    def site_url(self) -> str:
+        return self._site_url
+
+    @site_url.setter
+    def site_url(self, value: str) -> None:
+        self._site_url = value
+
+    def update(self, route_list: dict) -> None:
+        """
+        Update the site map with a new route list.
+
+        :param route_list: The route list to parse
+        """
         route: str
         entry: BaseObject
+        self._route_map = dict()
         for route, entry in route_list.items():
             if entry.skip_site_map:
                 continue
@@ -61,9 +81,8 @@ class SiteMap:
             self._route_map[sm_entry.slug] = sm_entry
             if sm_entry.entries:
                 self._collections[sm_entry.slug] = sm_entry
-        self.site_url = site_url
 
-    def __iter__(self):
+    def __iter__(self) -> Generator[SiteMapEntry]:
         """Iterator for the site map object"""
         for entry in self._route_map.values():
             yield entry

--- a/tests/test_site_map.py
+++ b/tests/test_site_map.py
@@ -79,7 +79,7 @@ def site(tmp_path_factory):
 
 
 def test_site_map_to_html(site):
-    sm = SiteMap(site.route_list, "")
+    sm = SiteMap("", site.route_list)
     assert sm.html == (
         "<ul>\n"
         '\t<li><a href="/coll1-route">coll1</a></li>\n'
@@ -127,7 +127,7 @@ def test_site_map_to_html(site):
     ],
 )
 def test_site_map_search(site, value, params, expected):
-    sm = SiteMap(site.route_list, "")
+    sm = SiteMap("", site.route_list)
     if expected is not None:
         found = sm.find(value, **params)
         assert isinstance(found, SiteMapEntry)


### PR DESCRIPTION
Resolves #1072

- Give default parameters to the `SiteMap` constructor.
- Convert `SiteMap.site_url` to property
- Add method `update` to `SiteMap`
- Initialize `Site` with, effectively, an empty `SiteMap`
- Update `SiteMap` during `render`
- Add optional parameter of `site_url` to `render` (this is for the API to be able to produce the site map with the correct URL for local serving.) 

#### Type of Issue

- [ ] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [X] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [ ] YES - Changes have been documented

IMO documentation is not needed as the user should not be mucking around with this. This change should be transparent to the user.

#### Changes have been Tested

- [X] YES - Changes have been tested

Functionally, there is no change that requires additional testing. The change to the test file was due to my reordering the parameters for the `SiteMap` constructor during work.

#### Next Steps

[Update the CLI](https://github.com/render-engine/render-engine-cli/issues/39) to use the correct local URL when running `serve`,

#### AI Attestation

No AI used in the creation of this PR.
