### PR TITLE
Move parsers back into render-engine core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,4 @@ untitled-site/
 .python-version
 
 __version__.py
+.worktress

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ dev = [
   "ephemeral-port-reserve",
   "deptry>=0.24.0",
   "httpx",
-  "ty==0.0.14", # TODO: Update typing with new versions in 0.0.24
+  # TODO: Update typing with new versions in 0.0.24
+  "ty==0.0.14",
   "pre-commit",
   "pytest",
   "pytest-cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,8 @@ dependencies = [
   "more-itertools",
   "pluggy",
   "python-dateutil",
+  "python-frontmatter==1.1.0",
   "python-slugify",
-  "render-engine-parser",
   "render-engine-markdown",
   "rich",
 ]
@@ -28,7 +28,7 @@ dev = [
   "ephemeral-port-reserve",
   "deptry>=0.24.0",
   "httpx",
-  "ty",
+  "ty==0.0.14", # TODO: Update typing with new versions in 0.0.24
   "pre-commit",
   "pytest",
   "pytest-cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dev = [
   "deptry>=0.24.0",
   "httpx",
   # TODO: Update typing with new versions in 0.0.24
+  # Issue URL: https://github.com/render-engine/render-engine/issues/1142
   "ty==0.0.14",
   "pre-commit",
   "pytest",

--- a/src/render_engine/__init__.py
+++ b/src/render_engine/__init__.py
@@ -2,6 +2,7 @@ from .blog import Blog
 from .collection import Collection
 from .data_object import DataObject
 from .page import Page
+from .parsers import BasePageParser
 from .site import Site
 
-__all__ = ["Blog", "Collection", "Page", "Site", "DataObject"]
+__all__ = ["Blog", "Collection", "Page", "Site", "DataObject", "BasePageParser"]

--- a/src/render_engine/collection.py
+++ b/src/render_engine/collection.py
@@ -9,7 +9,6 @@ from typing import Any, cast
 
 import dateutil.parser as dateparse
 from more_itertools import batched
-from render_engine_parser import BasePageParser
 from slugify import slugify
 
 from ._base_object import BaseObject
@@ -17,6 +16,7 @@ from .archive import Archive
 from .content_managers import ContentManager, FileContentManager
 from .feeds import RSSFeed
 from .page import Page
+from .parsers import BasePageParser
 from .plugins import PluginManager
 
 

--- a/src/render_engine/feeds.py
+++ b/src/render_engine/feeds.py
@@ -2,9 +2,8 @@
 Feed Objects for Generating RSS Feeds
 """
 
-from render_engine_parser import BasePageParser
-
 from .page import BasePage
+from .parsers import BasePageParser
 
 
 class RSSFeed(BasePage):

--- a/src/render_engine/page.py
+++ b/src/render_engine/page.py
@@ -4,11 +4,11 @@ from pathlib import Path
 from typing import Any, cast
 
 from jinja2 import Environment, Template
-from render_engine_parser.base_parsers import BasePageParser
 
 from render_engine.themes import ThemeManager
 
 from ._base_object import BaseObject
+from .parsers import BasePageParser
 from .plugins import PluginManager
 
 logger = logging.getLogger("Page")
@@ -85,9 +85,11 @@ class BasePage(BaseObject):
         :param **kwargs: Data to pass into the template for rendering.
         :return: The rendered page
         """
+
         template_data = {"data": self._data, "content": self._content}
         if site := getattr(self, "site", None):
             template_data["site_map"] = site.site_map
+
         if not self.no_prerender and isinstance(self._content, str) and re.search(r"{{.*?site_map.*?}}", self._content):
             # If the content looks like a template, try to render it.
             try:
@@ -237,14 +239,14 @@ class Page(BasePage):
 
         # Parse Content from the Content Path or the Content
         if content_path := (content_path or getattr(self, "content_path", None)):
-            self.metadata, self.content = self.Parser.parse_content_path(str(content_path))
+            self.metadata, self.content = self.Parser.parse_content_path(content_path)
 
         elif content := (content or getattr(self, "content", None)):
             self.metadata, self.content = self.Parser.parse_content(content)
 
         else:
             self.metadata = {}
-            self.content = None
+            self.content = ""
 
         # Set the attributes
         for key, val in self.metadata.items():
@@ -260,4 +262,7 @@ class Page(BasePage):
         Returns:
             Any: The parsed content of the page.
         """
-        return self.Parser.parse(self.content, extras=getattr(self, "parser_extras", {}))
+        content = getattr(self, "content", None)
+        if content:
+            return self.Parser.parse(content, extras=getattr(self, "parser_extras", {}))
+        return content

--- a/src/render_engine/page.py
+++ b/src/render_engine/page.py
@@ -262,7 +262,6 @@ class Page(BasePage):
         Returns:
             Any: The parsed content of the page.
         """
-        # TODO: Modify this to use the warlus. Or not.
         content = getattr(self, "content", None)
         if content:
             return self.Parser.parse(content, extras=getattr(self, "parser_extras", {}))

--- a/src/render_engine/page.py
+++ b/src/render_engine/page.py
@@ -262,6 +262,7 @@ class Page(BasePage):
         Returns:
             Any: The parsed content of the page.
         """
+        # TODO: Modify this to use the warlus. Or not.
         content = getattr(self, "content", None)
         if content:
             return self.Parser.parse(content, extras=getattr(self, "parser_extras", {}))

--- a/src/render_engine/parsers/__init__.py
+++ b/src/render_engine/parsers/__init__.py
@@ -1,0 +1,1 @@
+from .base_parsers import BasePageParser as BasePageParser

--- a/src/render_engine/parsers/__init__.py
+++ b/src/render_engine/parsers/__init__.py
@@ -1,1 +1,3 @@
-from .base_parsers import BasePageParser as BasePageParser
+from .base_parsers import BasePageParser
+
+__all__ = ["BasePageParser"]

--- a/src/render_engine/parsers/base_parsers.py
+++ b/src/render_engine/parsers/base_parsers.py
@@ -1,0 +1,76 @@
+import pathlib
+from typing import Any
+
+import frontmatter
+
+
+def parse_content(content: str) -> tuple[dict, str]:
+    """Fetching content and atttributes from a content_path"""
+    p = frontmatter.parse(content)
+    return p
+
+
+class BasePageParser:
+    """
+    The default Parser for Page objects.
+    This yields attributes and content using frontmatter.
+    The content is not modified.
+    """
+
+    @staticmethod
+    def parse_content_path(content_path: str | pathlib.Path) -> tuple[dict, str]:
+        """
+        Fetches content from `Page.content_path` and sets attributes.
+
+        This is a separate method so that it can be overridden by subclasses.
+
+        params:
+            content_path:
+                The path to the file that will be used to generate the Page's `content`.
+                Should be a valid path to a file or a url.
+        """
+        return parse_content(pathlib.Path(content_path).read_text())
+
+    @staticmethod
+    def parse_content(content: str) -> tuple[dict, str]:
+        """
+        Fetches content from `Page.content` and returns attributes and content.
+
+        This is a separate method so that it can be overridden by subclasses.
+
+        params:
+            content:
+                The path to the file that will be used to generate the Page's `content`.
+                Should be a valid path to a file or a url.
+        """
+
+        return parse_content(content)
+
+    @staticmethod
+    def parse(
+        content: str,
+        extras: dict[str, Any] | None = None,
+    ) -> str:
+        """
+        Parses content to be rendered into HTML
+
+        In the base parser, this returns the content as is.
+
+        params:
+            content: content to be rendered into HTML
+            extras: dictionary with extras to augment attributes
+        """
+        return content
+
+    @staticmethod
+    def create_entry(*, content: str = "Hello World", **kwargs) -> str:
+        """
+        Writes the content type that would be parsed to the content_path.
+        """
+
+        post = frontmatter.Post(content)
+
+        for key, val in kwargs.items():
+            post[key] = val
+
+        return frontmatter.dumps(post)

--- a/uv.lock
+++ b/uv.lock
@@ -1044,9 +1044,9 @@ dependencies = [
     { name = "more-itertools" },
     { name = "pluggy" },
     { name = "python-dateutil" },
+    { name = "python-frontmatter" },
     { name = "python-slugify" },
     { name = "render-engine-markdown" },
-    { name = "render-engine-parser" },
     { name = "rich" },
 ]
 
@@ -1084,10 +1084,10 @@ requires-dist = [
     { name = "more-itertools" },
     { name = "pluggy" },
     { name = "python-dateutil" },
+    { name = "python-frontmatter", specifier = "==1.1.0" },
     { name = "python-slugify" },
     { name = "render-engine-cli", marker = "extra == 'cli'" },
     { name = "render-engine-markdown" },
-    { name = "render-engine-parser" },
     { name = "render-engine-sitemap", marker = "extra == 'extras'" },
     { name = "rich" },
 ]
@@ -1103,7 +1103,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "toml" },
-    { name = "ty" },
+    { name = "ty", specifier = "==0.0.14" },
 ]
 docs = [
     { name = "mkdocs" },


### PR DESCRIPTION
Move `BasePageParser` from the external `render-engine-parser` package back into the core `render-engine` package as `render_engine.parsers`.

This replaces the `render-engine-parser` dependency with `python-frontmatter` directly and inlines the parser code.

There was an issue with ty being updated in the PR which broke typing... I pinned ty to the last version and added a TODO.

#### Type of Issue

- [x] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [ ] YES - Changes have been documented

#### Changes have been Tested

- [X] YES - Changes have been tested

#### Next Steps

- Verify downstream packages (e.g. `render-engine-markdown`) still work with the inlined parser.
- 
- Update documentation references if needed
- Update typing from ty

#### AI Attestation

AI (Claude) was used to create this draft PR description based on the commit history, diff.
The same model (opus 4.6) was made to refactor changes in in `page.py` to make code work (This was the setting of `self.content = "" in the self.__init__()` and assisted with troubleshooting the ty issues which lead to pinning the version (new issue needed to fix)
