### PR TITLE
Fix TODO-to-issue workflow with maintainer approval gate

### DIFF
--- a/.github/workflows/todos.yml
+++ b/.github/workflows/todos.yml
@@ -1,31 +1,89 @@
-name: "Run TODO to Issue"
+name: "TODO to Issue"
+
 on:
   pull_request:
+    types: [opened, synchronize, labeled]
     branches: [main]
+
 jobs:
-  build:
-    runs-on: "ubuntu-latest"
+  detect-todos:
+    if: github.event.action == 'opened' || github.event.action == 'synchronize'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check diff for TODOs
+        id: check
+        run: |
+          if git diff origin/main...HEAD | grep -q '^\+.*# *TODO'; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Comment on PR
+        if: steps.check.outputs.found == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+            const marker = '<!-- todo-to-issue-bot -->';
+            if (comments.some(c => c.body.includes(marker))) return;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `${marker}\nThis PR contains \`TODO\` comments. A maintainer can add the **todo-to-issue** label to automatically create GitHub issues and link them in the code.`
+            });
+
+  create-issues:
+    if: github.event.action == 'labeled' && github.event.label.name == 'todo-to-issue'
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       issues: write
       pull-requests: write
     steps:
-      - uses: "actions/checkout@v6"
-      - name: "TODO to Issue"
-        uses: "alstr/todo-to-issue-action@v5"
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: TODO to Issue
+        uses: alstr/todo-to-issue-action@v5
         with:
           INSERT_ISSUE_URLS: "true"
           CLOSES_ISSUE: "true"
-      - name: Set Git user
+
+      - name: Commit and push issue URLs
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-      - name: Commit and Push Changes
-        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
           if [[ `git status --porcelain` ]]; then
             git commit -m "Automatically added GitHub issue links to TODOs"
-            git push origin main
+            git push origin HEAD:${{ github.head_ref }}
           else
             echo "No changes to commit"
           fi
+
+      - name: Remove label
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              name: 'todo-to-issue'
+            });

--- a/docs/docs/contributing/CONTRIBUTING.md
+++ b/docs/docs/contributing/CONTRIBUTING.md
@@ -77,9 +77,17 @@ all supported versions.
 
 ## TODOs
 
-Todos are not encouraged all the time but if necessary please indicate any todos with the `# TODO Prefix`.
-We use [todo-to-issue] as a github action that will create issues for any TODOs that are created.
-This will modify your code with the issue number and link to the TODO in the comments.
+Todos are not encouraged all the time but if necessary please indicate any todos with the `# TODO` prefix.
+We use [todo-to-issue] as a GitHub Action to create issues from TODOs.
+
+When a PR containing `# TODO` comments is opened, a bot will comment suggesting a maintainer
+add the **todo-to-issue** label. Once a maintainer adds the label, the action will:
+
+1. Create GitHub issues for each TODO
+2. Update the TODO comments in your code with the issue number and link
+3. Commit the changes back to your PR branch
+
+The label is removed automatically afterward and can be re-applied if new TODOs are added.
 
 ## Contributing to Documentation
 


### PR DESCRIPTION
The previous TODO-to-issue workflow ran automatically on every PR and incorrectly pushed changes to `main`. This replaces it with a two-job, maintainer-gated approach.

**How it works:**

1. **`detect-todos`** — On every PR open/push, diffs against `main` for added `# TODO` lines. If found, posts a one-time comment (deduplicated via hidden HTML marker) suggesting a maintainer add the `todo-to-issue` label.
2. **`create-issues`** — Only runs when a maintainer adds the `todo-to-issue` label. Creates GitHub issues via `alstr/todo-to-issue-action`, commits the updated TODO comments (with issue URLs) back to the PR branch, and removes the label afterward so it can be re-applied if needed.

#### Type of Issue

- [ ] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [x] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [x] YES - Changes have been documented

#### Changes have been Tested

- [ ] YES - Changes have been tested

#### Next Steps

- Create the `todo-to-issue` label in the repo if it doesn't already exist
- Test on a PR with TODO comments to verify both jobs work as expected

#### AI Attestation

This change was authored with Claude Code (Claude Opus 4.6). The workflow logic, PR description, and commit message were all AI-assisted.