### PR TITLE
Pin dependency versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,10 @@ repos:
   rev: v0.6.0
   hooks:
     - id: markdownlint-cli2
+- repo: https://github.com/kjaymiller/pin-versions
+  rev: 2026.3.6
+  hooks:
+    - id: pin-versions
 - repo: local
   hooks:
     - id: deptry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,40 +9,40 @@ description = "A Flexible Static Site Generator for Python"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-  "jinja2",
-  "more-itertools",
-  "pluggy",
-  "python-dateutil",
+  "jinja2==3.1.6",
+  "more-itertools==10.8.0",
+  "pluggy==1.6.0",
+  "python-dateutil==2.9.0.post0",
   "python-frontmatter==1.1.0",
-  "python-slugify",
-  "render-engine-markdown",
-  "rich",
+  "python-slugify==8.0.4",
+  "render-engine-markdown==2023.12.1",
+  "rich==14.3.1",
 ]
 
 [project.optional-dependencies]
-cli = ["render-engine-cli"]
-extras = ["render-engine-sitemap"]
+cli = ["render-engine-cli==2025.11.1"]
+extras = ["render-engine-sitemap==2024.1.1a1"]
 
 [dependency-groups]
 dev = [
-  "ephemeral-port-reserve",
+  "ephemeral-port-reserve==1.1.4",
   "deptry>=0.24.0",
-  "httpx",
+  "httpx==0.28.1",
   # TODO: Update typing with new versions in 0.0.24
   # Issue URL: https://github.com/render-engine/render-engine/issues/1142
   "ty==0.0.14",
-  "pre-commit",
-  "pytest",
-  "pytest-cov",
-  "pytest-mock",
-  "toml",
+  "pre-commit==4.5.1",
+  "pytest==9.0.2",
+  "pytest-cov==7.0.0",
+  "pytest-mock==3.15.1",
+  "toml==0.10.2",
 ]
 docs = [
-  "mkdocs",
-  "mkdocs-material",
+  "mkdocs==1.6.1",
+  "mkdocs-material==9.7.6",
   "mkdocs-multirepo-plugin==0.8.3",
-  "mkdocstrings[python]",
-  "pymdown-extensions",
+  "mkdocstrings[python]==1.0.3",
+  "pymdown-extensions==10.21",
 ]
 
 [tool.setuptools_scm]

--- a/uv.lock
+++ b/uv.lock
@@ -689,7 +689,7 @@ wheels = [
 
 [[package]]
 name = "mkdocs-material"
-version = "9.7.1"
+version = "9.7.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
@@ -704,9 +704,9 @@ dependencies = [
     { name = "pymdown-extensions" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/e2/2ffc356cd72f1473d07c7719d82a8f2cbd261666828614ecb95b12169f41/mkdocs_material-9.7.1.tar.gz", hash = "sha256:89601b8f2c3e6c6ee0a918cc3566cb201d40bf37c3cd3c2067e26fadb8cce2b8", size = 4094392, upload-time = "2025-12-18T09:49:00.308Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/32/ed071cb721aca8c227718cffcf7bd539620e9799bbf2619e90c757bfd030/mkdocs_material-9.7.1-py3-none-any.whl", hash = "sha256:3f6100937d7d731f87f1e3e3b021c97f7239666b9ba1151ab476cabb96c60d5c", size = 9297166, upload-time = "2025-12-18T09:48:56.664Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z" },
 ]
 
 [[package]]
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "mkdocstrings"
-version = "1.0.2"
+version = "1.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
@@ -745,9 +745,9 @@ dependencies = [
     { name = "mkdocs-autorefs" },
     { name = "pymdown-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/4d/1ca8a9432579184599714aaeb36591414cc3d3bfd9d494f6db540c995ae4/mkdocstrings-1.0.2.tar.gz", hash = "sha256:48edd0ccbcb9e30a3121684e165261a9d6af4d63385fc4f39a54a49ac3b32ea8", size = 101048, upload-time = "2026-01-24T15:57:25.735Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/62/0dfc5719514115bf1781f44b1d7f2a0923fcc01e9c5d7990e48a05c9ae5d/mkdocstrings-1.0.3.tar.gz", hash = "sha256:ab670f55040722b49bb45865b2e93b824450fb4aef638b00d7acb493a9020434", size = 100946, upload-time = "2026-02-07T14:31:40.973Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/32/407a9a5fdd7d8ecb4af8d830b9bcdf47ea68f916869b3f44bac31f081250/mkdocstrings-1.0.2-py3-none-any.whl", hash = "sha256:41897815a8026c3634fe5d51472c3a569f92ded0ad8c7a640550873eea3b6817", size = 35443, upload-time = "2026-01-24T15:57:23.933Z" },
+    { url = "https://files.pythonhosted.org/packages/04/41/1cf02e3df279d2dd846a1bf235a928254eba9006dd22b4a14caa71aed0f7/mkdocstrings-1.0.3-py3-none-any.whl", hash = "sha256:0d66d18430c2201dc7fe85134277382baaa15e6b30979f3f3bdbabd6dbdb6046", size = 35523, upload-time = "2026-02-07T14:31:39.27Z" },
 ]
 
 [package.optional-dependencies]
@@ -869,15 +869,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.20.1"
+version = "10.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/6c/9e370934bfa30e889d12e61d0dae009991294f40055c238980066a7fbd83/pymdown_extensions-10.20.1.tar.gz", hash = "sha256:e7e39c865727338d434b55f1dd8da51febcffcaebd6e1a0b9c836243f660740a", size = 852860, upload-time = "2026-01-24T05:56:56.758Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/63/06673d1eb6d8f83c0ea1f677d770e12565fb516928b4109c9e2055656a9e/pymdown_extensions-10.21.tar.gz", hash = "sha256:39f4a020f40773f6b2ff31d2cd2546c2c04d0a6498c31d9c688d2be07e1767d5", size = 853363, upload-time = "2026-02-15T20:44:06.748Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/6d/b6ee155462a0156b94312bdd82d2b92ea56e909740045a87ccb98bf52405/pymdown_extensions-10.20.1-py3-none-any.whl", hash = "sha256:24af7feacbca56504b313b7b418c4f5e1317bb5fea60f03d57be7fcc40912aa0", size = 268768, upload-time = "2026-01-24T05:56:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/5b079febdc65e1c3fb2729bf958d18b45be7113828528e8a0b5850dd819a/pymdown_extensions-10.21-py3-none-any.whl", hash = "sha256:91b879f9f864d49794c2d9534372b10150e6141096c3908a455e45ca72ad9d3f", size = 268877, upload-time = "2026-02-15T20:44:05.464Z" },
 ]
 
 [[package]]
@@ -1080,37 +1080,37 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "jinja2" },
-    { name = "more-itertools" },
-    { name = "pluggy" },
-    { name = "python-dateutil" },
+    { name = "jinja2", specifier = "==3.1.6" },
+    { name = "more-itertools", specifier = "==10.8.0" },
+    { name = "pluggy", specifier = "==1.6.0" },
+    { name = "python-dateutil", specifier = "==2.9.0.post0" },
     { name = "python-frontmatter", specifier = "==1.1.0" },
-    { name = "python-slugify" },
-    { name = "render-engine-cli", marker = "extra == 'cli'" },
-    { name = "render-engine-markdown" },
-    { name = "render-engine-sitemap", marker = "extra == 'extras'" },
-    { name = "rich" },
+    { name = "python-slugify", specifier = "==8.0.4" },
+    { name = "render-engine-cli", marker = "extra == 'cli'", specifier = "==2025.11.1" },
+    { name = "render-engine-markdown", specifier = "==2023.12.1" },
+    { name = "render-engine-sitemap", marker = "extra == 'extras'", specifier = "==2024.1.1a1" },
+    { name = "rich", specifier = "==14.3.1" },
 ]
 provides-extras = ["cli", "extras"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "deptry", specifier = ">=0.24.0" },
-    { name = "ephemeral-port-reserve" },
-    { name = "httpx" },
-    { name = "pre-commit" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
-    { name = "pytest-mock" },
-    { name = "toml" },
+    { name = "ephemeral-port-reserve", specifier = "==1.1.4" },
+    { name = "httpx", specifier = "==0.28.1" },
+    { name = "pre-commit", specifier = "==4.5.1" },
+    { name = "pytest", specifier = "==9.0.2" },
+    { name = "pytest-cov", specifier = "==7.0.0" },
+    { name = "pytest-mock", specifier = "==3.15.1" },
+    { name = "toml", specifier = "==0.10.2" },
     { name = "ty", specifier = "==0.0.14" },
 ]
 docs = [
-    { name = "mkdocs" },
-    { name = "mkdocs-material" },
+    { name = "mkdocs", specifier = "==1.6.1" },
+    { name = "mkdocs-material", specifier = "==9.7.6" },
     { name = "mkdocs-multirepo-plugin", specifier = "==0.8.3" },
-    { name = "mkdocstrings", extras = ["python"] },
-    { name = "pymdown-extensions" },
+    { name = "mkdocstrings", extras = ["python"], specifier = "==1.0.3" },
+    { name = "pymdown-extensions", specifier = "==10.21" },
 ]
 
 [[package]]


### PR DESCRIPTION
Pins all dependency versions in `pyproject.toml` to exact versions and adds a [`pin-versions`](https://github.com/kjaymiller/pin-versions) pre-commit hook to enforce pinning going forward.

Closes #1130

#### Type of Issue

- [ ] :bug: (bug)
- [ ] :book: (Documentation)
- [x] :arrow_up: (Update)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [x] YES - Changes have been documented

#### Changes have been Tested

- [x] YES - Changes have been tested

#### Next Steps

None

#### AI Attestation

Claude Code assisted with PR descriptions creation.