### PR TITLE
Added section on extending RE to getting started

### DIFF
--- a/docs/docs/getting-started/creating-a-collection.md
+++ b/docs/docs/getting-started/creating-a-collection.md
@@ -84,10 +84,10 @@ class Heroes(Collection):
 
 The value of `42` can be accessed in your template using `{{collection.some_value}}`.
 
-## Continue to [Building your Site]
+## Continue to [Extending Render Engine]
 
 [collection-docs]: ../collection.md
 [Creating a Page]: creating-a-page.md
 [jinja-context]: https://jinja.palletsprojects.com/en/3.0.x/api/#the-context
 
-[building your site]: building-your-site.md
+[Extending Render Engine]: extending-render-engine.md

--- a/docs/docs/getting-started/extending-render-engine.md
+++ b/docs/docs/getting-started/extending-render-engine.md
@@ -4,8 +4,6 @@ description: "Extending Render Engine with custom plugins and themes."
 date: April 16, 2026
 tags: ["customization", "themes", "plugins", "render-engine"]
 ---
-# Extending Render Engine
-
 While Render Engine works great out of the box, there are times when you might
 want to extend it beyond the basics. To do this, you can use themes, plugins,
 and content managers.
@@ -26,6 +24,7 @@ more.
 
 For more information on writing and using plugins, check out the
 [Plugins page].
+
 ## Content Managers
 
 Render Engine uses Content Managers to handle loading the content. Render

--- a/docs/docs/getting-started/extending-render-engine.md
+++ b/docs/docs/getting-started/extending-render-engine.md
@@ -10,7 +10,7 @@ and content managers.
 
 ## Themes
 
-Themes s are a collection of Jinja templates and static files used to render
+Themes are a collection of Jinja templates and static files used to render
 your site.
 
 For more information on themes, check out the [ThemeManager page].

--- a/docs/docs/getting-started/extending-render-engine.md
+++ b/docs/docs/getting-started/extending-render-engine.md
@@ -1,0 +1,47 @@
+---
+title: "Extending Render Engine"
+description: "Extending Render Engine with custom plugins and themes."
+date: April 16, 2026
+tags: ["customization", "themes", "plugins", "render-engine"]
+---
+# Extending Render Engine
+
+While Render Engine works great out of the box, there are times when you might
+want to extend it beyond the basics. To do this, you can use themes, plugins,
+and content managers.
+
+## Themes
+
+Themes s are a collection of Jinja templates and static files used to render
+your site.
+
+For more information on themes, check out the [ThemeManager page].
+
+## Plugins
+
+Plugins are units of code that run at different points during the rendering
+process. Plugins can do things like transformations, rendering different
+types of content, adjusting formatting beyond what the parser handles, and
+more.
+
+For more information on writing and using plugins, check out the
+[Plugins page].
+## Content Managers
+
+Render Engine uses Content Managers to handle loading the content. Render
+Engine comes with a file system based content manager, but you could write
+your own to pull your content from a database, JSON file, or something else.
+
+For more information on writing and using plugins, check out the
+[Content Managers page].
+
+> **Note:** To find some of our favorite themes and plugins checkout out
+> [The Render Engine Awesome List]
+
+## Continue to [Building your Site]
+
+[ThemeManager Page]:../theme_management/
+[Plugins Page]:../plugins/
+[Content Managers Page]:../content_manager/
+[The Render Engine Awesome List]:https://github.com/render-engine/render-engine-awesome-list
+[building your site]: building-your-site.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
     - getting-started/layout.md
     - getting-started/creating-a-page.md
     - getting-started/creating-a-collection.md
+    - getting-started/extending-render-engine.md
     - getting-started/building-your-site.md
   - Contributing:
     - contributing/CODE_OF_CONDUCT.md


### PR DESCRIPTION
Resolves #1149 

Adds section on extending Render Engine to the Getting Started guide.

#### Type of Issue

- [ ] :bug: (bug)
- [X] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [X] YES - Changes have been documented

#### Changes have been Tested

- [ ] YES - Changes have been tested

#### Next Steps

Extend the general documentation on theme managers.

#### AI Attestation

It wasn't.
