### PR TITLE
Add support for page redirection.

### DIFF
--- a/src/render_engine/__init__.py
+++ b/src/render_engine/__init__.py
@@ -1,8 +1,8 @@
 from .blog import Blog
 from .collection import Collection
 from .data_object import DataObject
-from .page import Page
+from .page import Page, RedirectPage
 from .parsers import BasePageParser
 from .site import Site
 
-__all__ = ["Blog", "Collection", "Page", "Site", "DataObject", "BasePageParser"]
+__all__ = ["Blog", "Collection", "Page", "Site", "DataObject", "BasePageParser", "RedirectPage"]

--- a/src/render_engine/page.py
+++ b/src/render_engine/page.py
@@ -270,7 +270,7 @@ class Page(BasePage):
 
 class RedirectPage(Page):
     redirect_url: str
-    redirect_timeout: int = 5
+    redirect_timeout: int = 0
     template = "redirect.html"
     title = "Redirecting..."
 

--- a/src/render_engine/page.py
+++ b/src/render_engine/page.py
@@ -266,3 +266,26 @@ class Page(BasePage):
         if content:
             return self.Parser.parse(content, extras=getattr(self, "parser_extras", {}))
         return content
+
+
+class RedirectPage(Page):
+    redirect_url: str
+    redirect_timeout: int = 5
+    template = "redirect.html"
+    title = "Redirecting..."
+
+    def __init__(self, *args, **kwargs):
+        # Ensure we have a URL to redirect to.
+        if not getattr(self, "redirect_url", None):
+            raise RuntimeError("redirect_url must be set")
+
+        super().__init__(*args, **kwargs)
+
+        # If we don't have any content defined, use a default.
+        if not self.content:
+            self.content = f'Redirecting to "{self.redirect_url}" in {self.redirect_timeout} seconds.'
+
+        # Make sure the template will have access to the timeout and URL
+        self.template_vars = getattr(self, "template_vars", {})
+        self.template_vars["redirect_url"] = self.redirect_url
+        self.template_vars["redirect_timeout"] = self.redirect_timeout

--- a/src/render_engine/render_engine_templates/redirect.html
+++ b/src/render_engine/render_engine_templates/redirect.html
@@ -1,0 +1,4 @@
+{% extends "base_templates/_page.html" %}
+{% block head %}
+        <meta http-equiv="Refresh" content="{{redirect_timeout}}; URL={{redirect_url}}" />
+{% endblock %}

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -185,6 +185,7 @@ class TestRedirectPage:
 
         class TestPage(RedirectPage):
             redirect_url = "https://example.com"
+            redirect_timeout = 0
 
         test_page = TestPage(content=content, content_path=content_path)
         assert expected == test_page.content

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -4,7 +4,7 @@ import pathlib
 import jinja2
 import pytest
 
-from render_engine import Page
+from render_engine import Page, RedirectPage
 
 
 @pytest.fixture
@@ -165,3 +165,34 @@ def test_no_prerender():
         no_prerender = True
 
     assert CustomPage()._render_from_template(template=CustomPage.template) == "1234\n{{ site_map.find('test') }}"
+
+
+class TestRedirectPage:
+    @pytest.mark.parametrize(
+        "content, content_path, expected",
+        [
+            ("This is a test", False, "This is a test"),
+            ("This is a test", True, "This is a test"),
+            ("", False, 'Redirecting to "https://example.com" in 0 seconds.'),
+        ],
+    )
+    def test_renders_properly(self, tmp_path: pathlib.Path, content: str, content_path: bool, expected: str):
+        if content_path:
+            d = tmp_path / "test_page.md"
+            d.write_text(content)
+            content = None
+            content_path = d
+
+        class TestPage(RedirectPage):
+            redirect_url = "https://example.com"
+
+        test_page = TestPage(content=content, content_path=content_path)
+        assert expected == test_page.content
+
+    def test_invalid_initialization(self):
+        with pytest.raises(RuntimeError):
+
+            class TestPage(RedirectPage):
+                pass
+
+            TestPage()


### PR DESCRIPTION
Resolves #1160

Adds new `Page` subclass, `RedirectPage`. `RedirectPage` defaults to using a new template `redirect.html` which handles an HTML level redirection. 

`RedirectPage` requires `redirect_url` be set as a class level attribute. 

#### Type of Issue

- [ ] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [X] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [ ] YES - Changes have been documented

Since this is a prerequisite for #1159 the documentation should be handled with the full implementation of the feature in order to minimize confusion.

#### Changes have been Tested

- [X] YES - Changes have been tested

UTs added.
Local testing performed.

#### Next Steps

Add the functionality required by #1159
Add documentation for `RedirectPage`

#### AI Attestation

No LLMs were used in the creation of this change.