### PR TITLE
Use fetch-depth: 0 so setuptools_scm picks up tags in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v6.0.1
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.14"
@@ -45,6 +47,8 @@ jobs:
       fail-fast: true
     steps:
       - uses: actions/checkout@v6.0.1
+        with:
+          fetch-depth: 0
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
@@ -64,6 +68,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6.0.1
+        with:
+          fetch-depth: 0
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/ty.yml
+++ b/.github/workflows/ty.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.1
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v7
       - name: Run type (ty) check
         run: uv run ty check src


### PR DESCRIPTION
## Summary
- Adds `fetch-depth: 0` to all three `actions/checkout` steps in `.github/workflows/test.yml`.
- Without it, the shallow CI clone has no tags, `setuptools_scm` falls back to `0.0.dev…`, and uv re-resolution fails on dependabot PRs that touch `pyproject.toml` without updating `uv.lock` (see #1164 for a live example).
- Full diagnosis in #1169.

Fixes #1169

## Test plan
- [ ] All `test-against-python-matrix` jobs pass on this PR.
- [ ] After merge, comment `@dependabot rebase` on #1164 and confirm its matrix turns green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)