### PR TITLE
TEST (do not merge): fetch-tags variant for #1170

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-tags: true
       - uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.14"
@@ -37,7 +39,7 @@ jobs:
 
   test-against-python-matrix:
     # Only test all the supported versions when a pull request is made or the workflow is called
-    if: ${{github.event_name == 'workflow_call'}} || ${{github.event_name == 'pull_request'}}
+    if: ${{github.event_name == 'workflow_call'}} || ${{github.event_name == 'pull_request'}} || ${{github.event_name == 'workflow_dispatch'}}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -45,6 +47,8 @@ jobs:
       fail-fast: true
     steps:
       - uses: actions/checkout@v6.0.1
+        with:
+          fetch-tags: true
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
@@ -64,6 +68,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6.0.1
+        with:
+          fetch-tags: true
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "python-frontmatter==1.1.0",
   "python-slugify==8.0.4",
   "render-engine-markdown==2023.12.1",
-  "rich==14.3.3",
+  "rich==14.3.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
**Do not merge.** Comparison branch for #1170.

This branch uses `fetch-tags: true` with the default shallow clone (depth 1), instead of `fetch-depth: 0`. Pairs with #issue-1169-test-depth-0 to test whether tag refs alone are enough for setuptools_scm in CI.

## Repro setup

- All three `actions/checkout` steps use `fetch-tags: true` (no depth change)
- `rich` pinned to `14.3.1` (down from `14.3.3` on main) to force `uv` to re-resolve like a dependabot PR — this is what surfaces the bug in #1169
- `workflow_dispatch` added to the matrix-job `if:` so the workflow can be fired manually

## How to test

Run the workflow manually:
```bash
gh workflow run "PyTest" --ref issue-1169-test-fetch-tags
```

Then compare results against the depth-0 branch.

**Expected if fetch-tags is sufficient:** matrix passes.
**Expected if fetch-tags is insufficient:** matrix fails on the `cli` extra self-reference (same error as #1169).