### PR TITLE
TEST (do not merge): fetch-depth 0 variant for #1170

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v6.0.1
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.14"
@@ -37,7 +39,7 @@ jobs:
 
   test-against-python-matrix:
     # Only test all the supported versions when a pull request is made or the workflow is called
-    if: ${{github.event_name == 'workflow_call'}} || ${{github.event_name == 'pull_request'}}
+    if: ${{github.event_name == 'workflow_call'}} || ${{github.event_name == 'pull_request'}} || ${{github.event_name == 'workflow_dispatch'}}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -45,6 +47,8 @@ jobs:
       fail-fast: true
     steps:
       - uses: actions/checkout@v6.0.1
+        with:
+          fetch-depth: 0
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
@@ -64,6 +68,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6.0.1
+        with:
+          fetch-depth: 0
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/ty.yml
+++ b/.github/workflows/ty.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.1
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v7
       - name: Run type (ty) check
         run: uv run ty check src

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "python-frontmatter==1.1.0",
   "python-slugify==8.0.4",
   "render-engine-markdown==2023.12.1",
-  "rich==14.3.3",
+  "rich==14.3.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
**Do not merge.** Comparison branch for #1170.

This branch uses `fetch-depth: 0` (full history + tags) — the same approach as #1170. Pairs with #1171 to test whether tag refs alone are enough for setuptools_scm in CI.

## Repro setup

- All three `actions/checkout` steps use `fetch-depth: 0`
- `rich` pinned to `14.3.1` (down from `14.3.3` on main) to force `uv` to re-resolve like a dependabot PR — this is what surfaces the bug in #1169
- `workflow_dispatch` added to the matrix-job `if:` so the workflow can be fired manually

## How to test

Run the workflow manually:
```bash
gh workflow run "PyTest" --ref issue-1169-test-depth-0
```

Then compare results against #1171 (fetch-tags variant).

**Expected:** matrix passes — this is the control showing the fix works.