### PR TITLE
Slug only URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,5 @@ untitled-site/
 
 __version__.py
 .worktress
+
+output/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
   rev: v0.6.0
   hooks:
     - id: markdownlint-cli2
+      args: [ "*.md", "docs/**/*.md" ]
 - repo: https://github.com/kjaymiller/pin-versions
   rev: 2026.3.6
   hooks:

--- a/docs/docs/contributing/testing.md
+++ b/docs/docs/contributing/testing.md
@@ -76,5 +76,5 @@ uvx ruff format .
 uvx ruff check .
 ```
 
-[typechecking]: /contributing/typechecking/
+[typechecking]: typechecking.md
 [bun]: https://bun.com/docs

--- a/docs/docs/getting-started/building-your-site.md
+++ b/docs/docs/getting-started/building-your-site.md
@@ -38,5 +38,5 @@ render-engine build app:app
 
 Your site will be generated in the `output` folder.
 
-[cli-build]: ../cli/docs/cli.md#building-your-site-with-render-engine-build
+[cli-build]: ../cli/docs/cli.md#build
 [layout]: layout.md

--- a/docs/docs/getting-started/extending-render-engine.md
+++ b/docs/docs/getting-started/extending-render-engine.md
@@ -39,8 +39,8 @@ For more information on writing and using plugins, check out the
 
 ## Continue to [Building your Site]
 
-[ThemeManager Page]:../theme_management/
-[Plugins Page]:../plugins/
-[Content Managers Page]:../content_manager/
-[The Render Engine Awesome List]:https://github.com/render-engine/render-engine-awesome-list
+[ThemeManager Page]: ../theme_management.md
+[Plugins Page]: ../plugins.md
+[Content Managers Page]: ../content_manager.md
+[The Render Engine Awesome List]: https://github.com/render-engine/render-engine-awesome-list
 [building your site]: building-your-site.md

--- a/docs/docs/page.md
+++ b/docs/docs/page.md
@@ -26,13 +26,13 @@ This is not intended to be used directly.
 
 **Attributes:**
 
-| Name | Type | Description |
-| --- | --- | --- |
-| `slug` | | The slug of the page. Defaults to the `title` slugified. |
-| `content` | | The content to be rendered by the page |
-| `parser` | | The Parser used to parse the page's content. Defaults to `BasePageParser`. |
-| `reference` | | The attribute to use as the reference for the page in the site's route list. Defaults to `slug`. |
-| `skip_site_map` | `False` | When set to `True` the `Page` will not be included in the generated `SiteMap` |
+| Name            | Type    | Description                                                                                      |
+|-----------------|---------|--------------------------------------------------------------------------------------------------|
+| `slug`          |         | The slug of the page. Defaults to the `title` slugified.                                         |
+| `content`       |         | The content to be rendered by the page                                                           |
+| `parser`        |         | The Parser used to parse the page's content. Defaults to `BasePageParser`.                       |
+| `reference`     |         | The attribute to use as the reference for the page in the site's route list. Defaults to `slug`. |
+| `skip_site_map` | `False` | When set to `True` the `Page` will not be included in the generated `SiteMap`                    |
 
 ### Functions
 
@@ -67,20 +67,40 @@ When you create a page, you specify variables passed into rendering template.
 
 **Attributes:**
 
-<!-- markdownlint-disable MD013 -->
-| Name | Type | Description |
-| --- | --- | --- |
-| `content_path` | `str \| None` | The path to the file that will be used to generate the Page's `content`. |
-| `extension` | `str \| None` | The suffix to use for the page. Defaults to `.html`. |
-| `engine` | `str \| None` | If present, the engine to use for rendering the page. **This is normally not set and the `Site` 's engine will be used.** |
-| `reference` | `str \| None` | Used to determine how to reference the page in the `Site`'s route_list. Defaults to `slug`. |
-| `routes` | `str \| None` | The routes to use for the page. Defaults to `["./"]`. |
-| `template` | `str \| None` | The template used to render the page. If not provided, the `Site`'s `content`will be used. |
-| `Parser` | `type[BasePageParser]` | The parser to generate the page's `raw_content`. Defaults to `BasePageParser`. |
-| `title` | `str` | The title of the page. Defaults to the class name. |
-| `skip_site_map` | `bool` | When set to `True` the `Page` will not be included in the generated `SiteMap`. Defaults to `False`. |
-| `no_prerender` | `bool` | When set to `True` the `Page`'s `content` will not be pre-rendered as a `Template` even if `{{ site_map }}` is present. Defaults to `False`. |
-<!-- markdownlint-enable MD013 -->
+| Name             | Type                   | Description                                                                                                                                  |
+|------------------|:-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| `content_path`   | `str \| None`          | The path to the file that will be used to generate the Page's `content`.                                                                     |
+| `extension`      | `str \| None`          | The suffix to use for the page. Defaults to `.html`.                                                                                         |
+| `engine`         | `str \| None`          | If present, the engine to use for rendering the page. **This is normally not set and the `Site` 's engine will be used.**                    |
+| `reference`      | `str \| None`          | Used to determine how to reference the page in the `Site`'s route_list. Defaults to `slug`.                                                  |
+| `routes`         | `str \| None`          | The routes to use for the page. Defaults to `["./"]`.                                                                                        |
+| `template`       | `str \| None`          | The template used to render the page. If not provided, the `Site`'s `content`will be used.                                                   |
+| `Parser`         | `type[BasePageParser]` | The parser to generate the page's `raw_content`. Defaults to `BasePageParser`.                                                               |
+| `title`          | `str`                  | The title of the page. Defaults to the class name.                                                                                           |
+| `skip_site_map`  | `bool`                 | When set to `True` the `Page` will not be included in the generated `SiteMap`. Defaults to `False`.                                          |
+| `no_prerender`   | `bool`                 | When set to `True` the `Page`'s `content` will not be pre-rendered as a `Template` even if `{{ site_map }}` is present. Defaults to `False`. |
+| `slug_only_url`  | `bool \| None`         | See [Slug only URLS] for more details.                                                                                                       |
+
+### Slug only URLs
+
+When the `slug_only_url` attribute is set the page will render at `/{page.slug}` For example:
+
+```python
+class CustomPage(Page):
+    content = 'My content'
+    slug_only_url = True
+```
+
+The above `CustomPage` will render at `/custompage/index.html` and a [`RedirectPage`]
+will render at `custompage.html` that will point the browser to the actual page.
+
+Possible values for `slug_only_url`:
+
+| Value            | Meaning                                     |
+| ---------------- | ------------------------------------------- |
+| `True`           | Create a slug only URL with a redirect page |
+| `False`          | Do not create a slug only URL.              |
+| `None` (default) | Inherit behavior from the `Site` object.    |
 
 ## About Page Attributes
 
@@ -133,6 +153,28 @@ will render to the URL for `my_page` in the `content` and then in the generated 
 
 For more details on using the `SiteMap` please check the [SiteMap documentation][site_map].
 
+## RedirectPage
+
+The `RedirectPage` is a special page type. It will render as a normal page, however it includes additional
+`meta` tags that redirect the browser to a different URL. The `RedirectPage` has 2 special attributes:
+
+<!-- markdownlint-disable MD013 -->
+| Name               | Type  | Description                                      |
+|--------------------|-------|--------------------------------------------------|
+| `redirect_url`     | `str` | The URL to redirect the browser to.              |                                                                                                         |
+| `redirect_timeout` | `int` | How long to wait before reditecting the browser. |
+<!-- markdownlint-enable MD013 -->
+
+It should be noted that in order to achieve this, a `redirect.html` template is used. In order to maintain
+this functionality with your own template the following line should be included in the `<head>` block of
+your template:
+
+```html
+<meta http-equiv="Refresh" content="{{redirect_timeout}}; URL={{redirect_url}}" />
+```
+
 [parsers]: parsers.md
 [basepage]: page.md?id=basepage
 [site_map]: site_map.md
+[Slug only URLs]: #slug-only-urls
+[`RedirectPage`]: #redirectpage

--- a/docs/docs/site.md
+++ b/docs/docs/site.md
@@ -9,12 +9,13 @@ The site stores your pages and collections to be rendered.
 
 **Attributes:**
 
-| Name            | Type   | Description                                                   |
-| --------------- | ------ | ------------------------------------------------------------- |
-| `output_path`   | `str`  | path to write rendered content                                |
-| `static_paths`  | `set`  | paths for static folders copied to output (recursive)         |
-| `site_vars`     | `dict` | dictionary that will be passed into page template             |
-| `site_settings` |        | settings passed to pages and collections (not templates)      |
+| Name              | Type   | Description                                              |
+|-------------------|--------|----------------------------------------------------------|
+| `output_path`     | `str`  | path to write rendered content                           |
+| `static_paths`    | `set`  | paths for static folders copied to output (recursive)    |
+| `site_vars`       | `dict` | dictionary that will be passed into page template        |
+| `site_settings`   |        | settings passed to pages and collections (not templates) |
+| `slug_only_urls`  | `bool` | default value for pages for [`slug_only_url`]            |
 
 ## Functions
 
@@ -103,3 +104,4 @@ use the CLI command [`render-engine build`]
 [`render-engine build`]: cli.md?id=build
 [`site.collection`]: site.md?id=collection
 [`site.page`]: site.md?id=page
+[`slug_only_url`]: page.md#slug-only-urls

--- a/docs/docs/templates.md
+++ b/docs/docs/templates.md
@@ -120,5 +120,5 @@ Please see the [site map documentation] for more information.
 [jinja2-filters]: https://jinja.palletsprojects.com/en/3.1.x/templates/#filters
 [rfc822]: https://tools.ietf.org/html/rfc822
 
-[page object documentation]: /page/#accessing-urls-for-other-pages-in-the-site-from-within-the-page-content
-[site map documentation]: /site_map.html
+[page object documentation]: page.md#accessing-urls-for-other-pages-in-the-site-from-within-the-page-content
+[site map documentation]: site_map.md

--- a/justfile
+++ b/justfile
@@ -32,7 +32,7 @@ docs port="8000":
     mkdocs serve -f docs/mkdocs.yml -a 0.0.0.0:{{port}}
 
 # Run markdown linter (requires bun or npm)
-lint-md DIRECTORY=".":
+lint-md *DIRECTORY="*.md docs/**/*.md":  # Note that we don't want the ** glob from root because that will include site packages
     #!/usr/bin/env sh
     if command -v bun > /dev/null 2>&1; then
         bunx markdownlint-cli2 {{ DIRECTORY }}

--- a/src/render_engine/_base_object.py
+++ b/src/render_engine/_base_object.py
@@ -28,6 +28,10 @@ class BaseObject:
     plugin_settings: dict = {"plugins": defaultdict(dict)}
     skip_site_map: bool = False
     metadata: dict = dict()
+    _path_name: str | None = None
+
+    # Using bool or None to have an unset state
+    slug_only_url: bool | None = None
 
     @property
     def _title(self) -> str:
@@ -88,7 +92,7 @@ class BaseObject:
             str: The URL path for the object.
 
         """
-        return f"{self._slug}{self.extension}"
+        return self._path_name or f"{self._slug}{self.extension}"
 
     def url_for(self):
         """

--- a/src/render_engine/page.py
+++ b/src/render_engine/page.py
@@ -274,10 +274,15 @@ class RedirectPage(Page):
     template = "redirect.html"
     title = "Redirecting..."
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, redirect_url: str = "", **kwargs):
         # Ensure we have a URL to redirect to.
-        if not getattr(self, "redirect_url", None):
+        if redirect_url:
+            self.redirect_url = redirect_url
+        elif not getattr(self, "redirect_url", None):
             raise RuntimeError("redirect_url must be set")
+
+        if path_name := kwargs.pop("path_name", None):
+            self._path_name = path_name
 
         super().__init__(*args, **kwargs)
 

--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -295,9 +295,10 @@ class Site:
         """
         Handle automatic generation of redirect pages for all routes of an entry to "/{slug}/"
 
-        NOTE: This will mutate the entry to set the correct slug only URL and path name.
+        NOTE: This will mutate the entry to set the correct slug only URL and path name if
+              a slug only URL is requested.
 
-        :param _entry: The entry to add the slug URL for
+        :param entry: The entry to add the slug URL for
         """
         if not entry.slug_only_url:
             return

--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -11,7 +11,7 @@ from rich.progress import Progress
 from .collection import Collection
 from .data_object import DataObject
 from .engine import engine
-from .page import Page
+from .page import Page, RedirectPage
 from .plugins import PluginManager, handle_plugin_registration
 from .site_map import SiteMap
 from .themes import Theme, ThemeManager
@@ -63,6 +63,7 @@ class Site:
     plugin_settings: dict = {"plugins": defaultdict(dict)}
     render_html_site_map: bool = False
     render_xml_site_map: bool = False
+    slug_only_urls: bool = False
 
     def __init__(
         self,
@@ -219,6 +220,10 @@ class Site:
             page.plugin_manager.unregister_plugin(plugin)
 
         self.route_list[getattr(page, page._reference)] = page
+
+        # Default, unset state is None so check for that before assigning the value from Site
+        if page.slug_only_url is None:
+            page.slug_only_url = self.slug_only_urls
         return page
 
     def data_object(self, _data_object: type[DataObject]) -> DataObject:
@@ -286,6 +291,28 @@ class Site:
     def template_path(self, template_path: str) -> None:
         self.theme_manager.add_loader(0, FileSystemLoader(template_path))
 
+    def handle_slug_only_url(self, entry: Page | Collection):
+        """
+        Handle automatic generation of redirect pages for all routes of an entry to "/{slug}/"
+
+        NOTE: This will mutate the entry to set the correct slug only URL and path name.
+
+        :param _entry: The entry to add the slug URL for
+        """
+        if not entry.slug_only_url:
+            return
+        redirector = RedirectPage(redirect_url=f"/{entry._slug}", path_name=entry.path_name)
+        redirector.routes = entry.routes
+        redirector.site = self
+        redirector.render(self.theme_manager)
+        entry.routes = [f"./{entry._slug}"]
+        try:
+            # If someone set the path_name and overrode the property we need to do this.
+            entry.path_name = "index.html"  # type: ignore
+        except AttributeError:
+            # If the path_name is still a property it will raise an AttributeError
+            entry._path_name = "index.html"
+
     def render(self, site_url: str | None = None) -> None:
         """
         Render all pages and collections.
@@ -351,6 +378,7 @@ class Site:
             self.theme_manager.engine.globals["routes"] = self.route_list
 
             for slug, entry in self.route_list.items():
+                print(f"Hanlding {entry._slug = }")
                 entry.site = self
                 progress.update(task_add_route, description=f"[blue]Adding[gold]Route: [blue]{slug}")
                 args = []
@@ -361,6 +389,7 @@ class Site:
                             description=f"[blue]Adding[gold]Route: [blue]{entry._slug}",
                         )
                         args = [self.theme_manager]
+                        self.handle_slug_only_url(entry)
                     case Collection():
                         progress.update(
                             task_add_route,

--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -302,11 +302,12 @@ class Site:
         """
         if not entry.slug_only_url:
             return
-        redirector = RedirectPage(redirect_url=f"/{entry._slug}", path_name=entry.path_name)
+        slug = getattr(entry, "slug", entry._slug)
+        redirector = RedirectPage(redirect_url=f"/{slug}", path_name=entry.path_name)
         redirector.routes = entry.routes
         redirector.site = self
         redirector.render(self.theme_manager)
-        entry.routes = [f"./{entry._slug}"]
+        entry.routes = [f"./{slug}"]
         try:
             # If someone set the path_name and overrode the property we need to do this.
             entry.path_name = "index.html"  # type: ignore

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -367,3 +367,45 @@ def test_site_with_data_object(tmp_path, seri_in, seri_out, kwargs):
     site.render()
     output_file = (output_path / output_filename).read_text()
     assert seri_in(output_file) == source_data
+
+
+def test_site_slug_only_url_page(site, tmp_path: Path):
+    """Tests site outputs to output_path"""
+
+    @site.page
+    class CustomPage(Page):
+        content = "this is a test"
+        slug_only_url = True
+
+    site.render()
+
+    assert (site.output_path / "custompage.html").exists()
+    assert (site.output_path / "custompage/index.html").exists()
+
+
+def test_site_slug_only_url_site(site, tmp_path: Path):
+    """Tests site outputs to output_path"""
+    site.slug_only_urls = True
+
+    @site.page
+    class CustomPage(Page):
+        content = "this is a test"
+
+    site.render()
+
+    assert (site.output_path / "custompage.html").exists()
+    assert (site.output_path / "custompage/index.html").exists()
+
+
+def test_site_slug_only_url_site_false(site, tmp_path: Path):
+    """Tests site outputs to output_path"""
+    site.slug_only_urls = False
+
+    @site.page
+    class CustomPage(Page):
+        content = "this is a test"
+
+    site.render()
+
+    assert (site.output_path / "custompage.html").exists()
+    assert not (site.output_path / "custompage/index.html").exists()


### PR DESCRIPTION
Resolves #1154
Resolves #1159
Resolves #1166 

- Adds option to render slug only URLs at the `Site` and `Page` level
- Adds `output` to `.gitignore`
- Fixes issue with `lint-md` recipe in the Justfile
- Fixes issue with non-relative links in the docs
- Fixes _some_ table formatting in the docs

#### Type of Issue

- [ ] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [X] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [X] YES - Changes have been documented

#### Changes have been Tested

- [X] YES - Changes have been tested

#### Next Steps

#### AI Attestation

No LLM was used in the creation of this pull request
