### PR TITLE
Issues with `slug_only_url`

### DIFF
--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -382,7 +382,6 @@ class Site:
             self.theme_manager.engine.globals["routes"] = self.route_list
 
             for slug, entry in self.route_list.items():
-                print(f"Hanlding {entry._slug = }")
                 entry.site = self
                 progress.update(task_add_route, description=f"[blue]Adding[gold]Route: [blue]{slug}")
                 args = []

--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -352,6 +352,7 @@ class Site:
                     path_name = "site_map.html"
                     content = self._site_map.html
                     template = "page.html"
+                    slug_only_url = False
 
             if self.render_xml_site_map:
 
@@ -359,6 +360,7 @@ class Site:
                 class SiteMapXml(Page):
                     path_name = "site_map.xml"
                     template = "sitemap.xml"
+                    slug_only_url = False
 
             progress.update(task_site_map, advance=1)
 

--- a/src/render_engine/site_map.py
+++ b/src/render_engine/site_map.py
@@ -21,7 +21,10 @@ class SiteMapEntry:
         match entry:
             case Page() | DataObject():
                 # For a base page the _route created if we use the route is invalid - just use the path_name
-                self._route = f"/{route.lstrip('/')}/{self.path_name}" if from_collection else f"/{self.path_name}"
+                if entry.slug_only_url:
+                    self._route = f"/{self.slug}"
+                else:
+                    self._route = f"/{route.lstrip('/')}/{self.path_name}" if from_collection else f"/{self.path_name}"
                 self.entries = list()
             case Collection():
                 self._route = f"/{str(entry.routes[0]).lstrip('/')}"

--- a/tests/test_site_map.py
+++ b/tests/test_site_map.py
@@ -74,6 +74,7 @@ def site(tmp_path_factory):
             content_path = tmp_input_path / f"page{n}.md"
             template = template_file_name
             skip_site_map = n == 3
+            slug_only_url = n == 2
 
     yield site
 
@@ -98,7 +99,7 @@ def test_site_map_to_html(site):
         "\t</ul>\n"
         '\t<li><a href="/page0.html">Page 0</a></li>\n'
         '\t<li><a href="/page1.html">Page 1</a></li>\n'
-        '\t<li><a href="/page2.html">Page 2</a></li>\n'
+        '\t<li><a href="/page2">Page 2</a></li>\n'
         "</ul>\n"
     )
 
@@ -185,7 +186,7 @@ def test_site_map_to_xml(site):
 	<loc>http://localhost:8000/page1.html</loc>
 </url>
 <url>
-	<loc>http://localhost:8000/page2.html</loc>
+	<loc>http://localhost:8000/page2</loc>
 </url>
 </urlset>"""
     )


### PR DESCRIPTION
- Disable `slug_only_url` for site map outputs
- Fix issue where site map generation was not using `slug_only_url`

#### Type of Issue

- [x] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

NA
- [ ] YES - Changes have been documented

#### Changes have been Tested

- [X] YES - Changes have been tested

#### Next Steps

Continue with testing to see if other issues arise.

#### AI Attestation

No LLM usage in this PR
