### PR TITLE
issue-1177

### DIFF
--- a/docs/docs/data_object.md
+++ b/docs/docs/data_object.md
@@ -16,13 +16,13 @@ site rendering.
 
 ### Attributes
 
-| Name              | Type          | Description                                                               |
-|-------------------|---------------|---------------------------------------------------------------------------|
-| `data_object`     | `Any`         | The object to serialize.                                                  |
-| `serializer`      | 'Callable`    | The function to serialize with.                                           |
-| `serializer_args` | dict          | Optional `kwargs` to be passed to the `serializer` along with the object. |
-| `routes`          | list          | List of directories to output the serialized object to.                   |
-| `path_name`       | `str \| Path` | The filename to output the serialized data to.                            |
+| Name              | Type         | Description                                                               |
+|-------------------|--------------|---------------------------------------------------------------------------|
+| `data_object`     | `Any`        | The object to serialize.                                                  |
+| `serializer`      | `Callable`   | The function to serialize with.                                           |
+| `serializer_args` | `dict`       | Optional `kwargs` to be passed to the `serializer` along with the object. |
+| `routes`          | `list`       | List of directories to output the serialized object to.                   |
+| `path_name`       | `str | Path` | The filename to output the serialized data to.                            |
 
 The `serializer` is a function that takes a single positional argument and optional `**kwargs`. Should you wish to use
 a function with a different signature, you will need to write a wrapper around it.

--- a/docs/docs/data_object.md
+++ b/docs/docs/data_object.md
@@ -16,6 +16,7 @@ site rendering.
 
 ### Attributes
 
+<!-- markdownlint-disable MD060 -->
 | Name              | Type         | Description                                                               |
 |-------------------|--------------|---------------------------------------------------------------------------|
 | `data_object`     | `Any`        | The object to serialize.                                                  |
@@ -23,6 +24,7 @@ site rendering.
 | `serializer_args` | `dict`       | Optional `kwargs` to be passed to the `serializer` along with the object. |
 | `routes`          | `list`       | List of directories to output the serialized object to.                   |
 | `path_name`       | `str | Path` | The filename to output the serialized data to.                            |
+<!-- markdownlint-enable MD060 -->
 
 The `serializer` is a function that takes a single positional argument and optional `**kwargs`. Should you wish to use
 a function with a different signature, you will need to write a wrapper around it.

--- a/docs/docs/page.md
+++ b/docs/docs/page.md
@@ -69,17 +69,17 @@ When you create a page, you specify variables passed into rendering template.
 
 | Name             | Type                   | Description                                                                                                                                  |
 |------------------|:-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
-| `content_path`   | `str \| None`          | The path to the file that will be used to generate the Page's `content`.                                                                     |
-| `extension`      | `str \| None`          | The suffix to use for the page. Defaults to `.html`.                                                                                         |
-| `engine`         | `str \| None`          | If present, the engine to use for rendering the page. **This is normally not set and the `Site` 's engine will be used.**                    |
-| `reference`      | `str \| None`          | Used to determine how to reference the page in the `Site`'s route_list. Defaults to `slug`.                                                  |
-| `routes`         | `str \| None`          | The routes to use for the page. Defaults to `["./"]`.                                                                                        |
-| `template`       | `str \| None`          | The template used to render the page. If not provided, the `Site`'s `content`will be used.                                                   |
+| `content_path`   | `str | None`           | The path to the file that will be used to generate the Page's `content`.                                                                     |
+| `extension`      | `str | None`           | The suffix to use for the page. Defaults to `.html`.                                                                                         |
+| `engine`         | `str | None`           | If present, the engine to use for rendering the page. **This is normally not set and the `Site` 's engine will be used.**                    |
+| `reference`      | `str | None`           | Used to determine how to reference the page in the `Site`'s route_list. Defaults to `slug`.                                                  |
+| `routes`         | `str | None`           | The routes to use for the page. Defaults to `["./"]`.                                                                                        |
+| `template`       | `str | None`           | The template used to render the page. If not provided, the `Site`'s `content`will be used.                                                   |
 | `Parser`         | `type[BasePageParser]` | The parser to generate the page's `raw_content`. Defaults to `BasePageParser`.                                                               |
 | `title`          | `str`                  | The title of the page. Defaults to the class name.                                                                                           |
 | `skip_site_map`  | `bool`                 | When set to `True` the `Page` will not be included in the generated `SiteMap`. Defaults to `False`.                                          |
 | `no_prerender`   | `bool`                 | When set to `True` the `Page`'s `content` will not be pre-rendered as a `Template` even if `{{ site_map }}` is present. Defaults to `False`. |
-| `slug_only_url`  | `bool \| None`         | See [Slug only URLS] for more details.                                                                                                       |
+| `slug_only_url`  | `bool | None`          | See [Slug only URLS] for more details.                                                                                                       |
 
 ### Slug only URLs
 

--- a/docs/docs/page.md
+++ b/docs/docs/page.md
@@ -67,6 +67,7 @@ When you create a page, you specify variables passed into rendering template.
 
 **Attributes:**
 
+<!-- markdownlint-disable MD060 -->
 | Name             | Type                   | Description                                                                                                                                  |
 |------------------|:-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
 | `content_path`   | `str | None`           | The path to the file that will be used to generate the Page's `content`.                                                                     |
@@ -80,6 +81,7 @@ When you create a page, you specify variables passed into rendering template.
 | `skip_site_map`  | `bool`                 | When set to `True` the `Page` will not be included in the generated `SiteMap`. Defaults to `False`.                                          |
 | `no_prerender`   | `bool`                 | When set to `True` the `Page`'s `content` will not be pre-rendered as a `Template` even if `{{ site_map }}` is present. Defaults to `False`. |
 | `slug_only_url`  | `bool | None`          | See [Slug only URLS] for more details.                                                                                                       |
+<!-- markdownlint-enable MD060 -->
 
 ### Slug only URLs
 

--- a/justfile
+++ b/justfile
@@ -9,7 +9,7 @@ default:
 
 # Sync dependencies using uv
 sync:
-    uv sync --dev
+    uv sync --dev --group docs
 
 # Run pytest
 test *FLAGS='':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ docs = [
   "mkdocs-material==9.7.6",
   "mkdocs-multirepo-plugin==0.8.3",
   "mkdocstrings[python]==1.0.3",
-  "pymdown-extensions==10.21",
+  "pymdown-extensions==10.21.3",
 ]
 
 [tool.setuptools_scm]

--- a/uv.lock
+++ b/uv.lock
@@ -842,15 +842,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21"
+version = "10.21.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/63/06673d1eb6d8f83c0ea1f677d770e12565fb516928b4109c9e2055656a9e/pymdown_extensions-10.21.tar.gz", hash = "sha256:39f4a020f40773f6b2ff31d2cd2546c2c04d0a6498c31d9c688d2be07e1767d5", size = 853363, upload-time = "2026-02-15T20:44:06.748Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/2c/5b079febdc65e1c3fb2729bf958d18b45be7113828528e8a0b5850dd819a/pymdown_extensions-10.21-py3-none-any.whl", hash = "sha256:91b879f9f864d49794c2d9534372b10150e6141096c3908a455e45ca72ad9d3f", size = 268877, upload-time = "2026-02-15T20:44:05.464Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
 ]
 
 [[package]]
@@ -1092,7 +1092,7 @@ docs = [
     { name = "mkdocs-material", specifier = "==9.7.6" },
     { name = "mkdocs-multirepo-plugin", specifier = "==0.8.3" },
     { name = "mkdocstrings", extras = ["python"], specifier = "==1.0.3" },
-    { name = "pymdown-extensions", specifier = "==10.21" },
+    { name = "pymdown-extensions", specifier = "==10.21.3" },
 ]
 
 [[package]]


### PR DESCRIPTION
Resolves #1177

- Bumps `pymdown-extenstions` to 10.21.3 - Fixes issue with code blocks not rendering.
- Fixed issue with attribute type hints including unneeded '\\' to escape `|` which was being rendered.
- Add `--group docs` to the justfile `sync` recipe because there is no reason to not have the docs dependencies installed for local development.

#### Type of Issue

- [X] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

NA
- [ ] YES - Changes have been documented

#### Changes have been Tested

- [X] YES - Changes have been tested

#### Next Steps

None

#### AI Attestation

No LLM usage in this PR