### PR TITLE
Refactor `Site` to allow setting attributes via constructor.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,4 +170,4 @@ untitled-site/
 __version__.py
 .worktress
 
-output/*
+output/

--- a/docs/docs/getting-started/layout.md
+++ b/docs/docs/getting-started/layout.md
@@ -44,13 +44,14 @@ from render_engine_kjaymiller_theme import kjaymiller
 from render_engine_youtube_embed import YouTubeEmbed
 
 # create Site() as `app` or `site`
-# add your `output_path` (if not default)
-# add local `static_paths`
-# register plugins and themes
+# setting your `output_path` (if not default)
+# and local `static_paths`
+app = Site(
+            output_path = "output",
+            static_paths = {"static"},
+          )
 
-app = Site()
-app.output_path = "output"
-app.static_paths.add("static")
+# register plugins and themes
 app.register_plugins(YouTubeEmbed)
 app.register_theme(kjaymiller)
 

--- a/docs/docs/site.md
+++ b/docs/docs/site.md
@@ -9,15 +9,57 @@ The site stores your pages and collections to be rendered.
 
 **Attributes:**
 
-| Name              | Type   | Description                                              |
-|-------------------|--------|----------------------------------------------------------|
-| `output_path`     | `str`  | path to write rendered content                           |
-| `static_paths`    | `set`  | paths for static folders copied to output (recursive)    |
-| `site_vars`       | `dict` | dictionary that will be passed into page template        |
-| `site_settings`   |        | settings passed to pages and collections (not templates) |
-| `slug_only_urls`  | `bool` | default value for pages for [`slug_only_url`]            |
+| Name                   | Type     | Description                                                    |
+|------------------------|----------|----------------------------------------------------------------|
+| `output_path`          | `str`    | path to write rendered content                                 |
+| `static_paths`         | `set`    | paths for static folders copied to output (recursive)          |
+| `site_vars`            | `dict`   | dictionary that will be passed into page template              |
+| `render_html_site_map` | `bool`   | When True render the site map as an HTML file. Default: False. |
+| `render_xml_site_map`  | `bool`   | When True render the site map as an XML file. Default: False.  |
+| `slug_only_urls`       | `bool`   | default value for pages for [`slug_only_url`]                  |
+
+> !!! Note
+    These attributes can be set as class level attributes when subclassing `Site`, as parameters during instantiation,
+    or updated as attributes later on. If they are set as class level attributes those values will be used during
+    instantiation regardless of what is sent to the constructor.
 
 ## Functions
+
+### `Site()`
+
+```python
+from render_engine import Site
+
+Site(
+    *,
+    output_path: str | Path = "output",
+    template_path: str | Path = "templates",
+    static_paths: set[str | Path] = {"static"},
+    plugin_settings: object | dict = SENTINEL,
+    render_html_site_map: bool = False,
+    render_xml_site_map: bool = False,
+    slug_only_urls: bool = False,
+    site_vars: object | dict = SENTINEL,
+) -> None:
+    pass
+```
+
+The `Site` constructor takes the following keyword arguments:
+
+<!-- markdownlint-disable MD056 -->
+<!-- markdownlint-disable MD060 -->
+| Name                   | Type         | Description                                                                              |
+|------------------------|--------------|------------------------------------------------------------------------------------------|
+| `output_path`          | `str | Path` | Path to write rendered content.                                                          |
+| `template_path`        | `str | Path` | Path to location of template files.                                                      |
+| `static_paths`         | `str | Path` | Paths for static folders copied to output (recursive).                                   |
+| `plugin_settings`      | `dict`       | Dictionary caontaining plugin settings.                                                  |
+| `render_html_site_map` | `bool`       | When True render the site map as an HTML file. Default: False.                           |
+| `render_xml_site_map`  | `bool`       | When True render the site map as an XML file. Default: False.                            |
+| `slug_only_urls`       | `bool`       | Default value for Page objects rendering slub only URLS. Default: False                  |
+| `site_vars`            | `dict`       | The site_vars dictionary containing data to be passed to all templates during rendering. |
+<!-- markdownlint-enable MD056 -->
+<!-- markdownlint-enable MD060 -->
 
 ### `collection(Collection)`
 

--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -22,6 +22,8 @@ try:
 except ImportError:
     re_version = "development"
 
+SENTINEL: object = object()
+
 
 class Site:
     """
@@ -50,35 +52,71 @@ class Site:
         template_path: The path to the template files used for rendering.
     """
 
-    site_vars: dict = {
-        "SITE_TITLE": "Untitled Site",
-        "SITE_URL": "http://localhost:8000/",
-        "DATETIME_FORMAT": "%d %b %Y %H:%M %Z",
-        "head": set(),
-        "theme": {},
-    }
-    _output_path: str | Path = "output"
-    _template_path: str | Path = "templates"
-    _static_paths: set = {"static"}
-    plugin_settings: dict = {"plugins": defaultdict(dict)}
-    render_html_site_map: bool = False
-    render_xml_site_map: bool = False
-    slug_only_urls: bool = False
-
     def __init__(
         self,
+        *,
+        output_path: str | Path = "output",
+        template_path: str | Path = "templates",
+        static_paths: set[str | Path] = {"static"},
+        plugin_settings: object | dict = SENTINEL,
+        render_html_site_map: bool = False,
+        render_xml_site_map: bool = False,
+        slug_only_urls: bool = False,
+        site_vars: object | dict = SENTINEL,
     ) -> None:
+        """
+        Constructor for the Site object.
+
+        Note that attributes set as class attributes while subclassing Site will override
+        parameters sent via this constructor.
+
+        :param output_path: Path to write rendered content
+        :param template_path: Path to location of template files
+        :param static_paths: Paths for static folders copied to output (recursive)
+        :param plugin_settings: Dictionary caontaining plugin settings
+        :param render_html_site_map: When True render the site map as an HTML file. Default: False
+        :param render_xml_site_map: When True render the site map as an XMK file. Default: False
+        :param slug_only_urls: Default value for Page objects rendering slub only URLS. Default: False
+        :param site_vars: The site_vars dictionary containing data to be passed to all templates during rendering
+        """
+        # Use getattr for the attributes moved from class level to constructor arguments
+        # to properly handle subclassing. This will prefeer the value from the subclass
+        # for these attributes
+        template_path = getattr(self, "_template_path", template_path)
+        output_path = getattr(self, "_output_path", output_path)
+        static_paths = getattr(self, "_static_paths", static_paths)
+        self.plugin_settings: dict = getattr(
+            self, "plugin_settings", {"plugins": defaultdict(dict)} if plugin_settings is SENTINEL else plugin_settings
+        )
+        self.render_xml_site_map: bool = getattr(self, "render_xml_site_map", render_xml_site_map)
+        self.render_html_site_map: bool = getattr(self, "render_html_site_map", render_html_site_map)
+        self.slug_only_urls: bool = getattr(self, "slug_only_urls", slug_only_urls)
+
         self.plugin_manager: PluginManager = PluginManager()
         self.theme_manager = ThemeManager(
             engine=engine,
-            output_path=self._output_path,
-            static_paths=self._static_paths,
+            output_path=output_path,
+            static_paths=static_paths,
         )
+
+        self.site_vars: dict = getattr(
+            self,
+            "site_vars",
+            {
+                "SITE_TITLE": "Untitled Site",
+                "SITE_URL": "http://localhost:8000/",
+                "DATETIME_FORMAT": "%d %b %Y %H:%M %Z",
+                "head": set(),
+                "theme": {},
+            }
+            if site_vars is SENTINEL
+            else site_vars,
+        )
+
         self.route_list: dict = {}
-        self.site_settings: dict = {}
         self.subcollections: dict[str, list] = {"pages": []}
         self.theme_manager.engine.globals.update(self.site_vars)
-        self.theme_manager.add_loader(0, FileSystemLoader(self._template_path))
+        self.theme_manager.add_loader(0, FileSystemLoader(template_path))
         self._site_map = SiteMap()
 
     @property

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1,4 +1,5 @@
 import json
+from collections import defaultdict
 from pathlib import Path
 
 import pluggy
@@ -409,3 +410,59 @@ def test_site_slug_only_url_site_false(site, tmp_path: Path):
 
     assert (site.output_path / "custompage.html").exists()
     assert not (site.output_path / "custompage/index.html").exists()
+
+
+def test_site_constructor():
+    """Tests that variables set via the constructor work"""
+    test_kwargs = {
+        "output_path": "override",
+        "template_path": "override",
+        "static_paths": {"override"},
+        "plugin_settings": {},
+        "render_html_site_map": True,
+        "render_xml_site_map": True,
+        "slug_only_urls": True,
+        "site_vars": {},
+    }
+    site = Site(**test_kwargs)
+    for attr, value in test_kwargs.items():
+        assert getattr(site, attr) == value, f"Failure at {attr}"
+
+
+def test_site_constructor_sub_class():
+    """Tests that attributes set when subclassing override the constructor"""
+    test_kwargs = {
+        "output_path": "override",
+        "template_path": "override",
+        "static_paths": {"override"},
+        "plugin_settings": {},
+        "render_html_site_map": True,
+        "render_xml_site_map": True,
+        "slug_only_urls": True,
+        "site_vars": {},
+    }
+
+    class TestSite(Site):
+        _output_path: str | Path = "output_override"
+        _template_path: str | Path = "templates_override"
+        _static_paths: set = {"static_override"}
+        plugin_settings: dict = {"plugins_override": defaultdict(dict)}
+        render_html_site_map: bool = False
+        render_xml_site_map: bool = True
+        slug_only_urls: bool = False
+        site_vars: dict = {"site_vars_override": True}
+
+    site = TestSite(**test_kwargs)
+    expected_attrs = {
+        "output_path": TestSite._output_path,
+        "template_path": TestSite._template_path,
+        "static_paths": TestSite._static_paths,
+        "plugin_settings": TestSite.plugin_settings,
+        "render_html_site_map": TestSite.render_html_site_map,
+        "render_xml_site_map": TestSite.render_xml_site_map,
+        "slug_only_urls": TestSite.slug_only_urls,
+        "site_vars": TestSite.site_vars,
+    }
+
+    for attr, value in expected_attrs.items():
+        assert getattr(site, attr) == value, f"Failure at {attr}"


### PR DESCRIPTION
Resolves #1181

Allows for setting of user controlled attributes for `Site` to be handled via constructor.

!!! Note
    Because there is a potential that users have used subclassing to handle this the behaviour is to use the attribute from the subclass when set and ignore the value sent to the constructor. This is solely for backwards compatibility. New users should not be subclassing `Site`

#### Type of Issue

- [ ] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [x] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [x] YES - Changes have been documented

#### Changes have been Tested

- [x] YES - Changes have been tested

#### Next Steps

None

#### AI Attestation

LLMs were not used in the creation of this PR.
