### PR TITLE
Remove `render-engine-sitemap` from extras.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-[extras = ""]
+extras = []
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-extras = ["render-engine-sitemap==2024.1.1a1"]
+[extras = ""]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION

Removes `render-engine-sitemap` from the `extras` optional dependencies group. That project has been superseded by the site map generation in the engine itself and is now causing issues with dependabot updates. 

#### Type of Issue

- [x] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [ ] YES - Changes have been documented
N/A

#### Changes have been Tested

- [ ] YES - Changes have been tested
N/A

#### Next Steps

None

#### AI Attestation

No LLM was used for the creation of this PR. 