### PR TITLE
Fix: PreRelease.yaml and Python Script so that it actually runs

### DIFF
--- a/.github/scripts/publish_prerelease.py
+++ b/.github/scripts/publish_prerelease.py
@@ -23,6 +23,8 @@ surrounding project environment:
     uv run --script .github/scripts/publish_prerelease.py selftest
 """
 
+import shlex
+import subprocess
 from datetime import date
 
 import rich_click as click
@@ -53,6 +55,15 @@ def cli() -> None:
 def bump(current: str) -> None:
     """Print the next prerelease version after CURRENT (e.g. 2026.6.1b1)."""
     click.echo(next_version(Version(current), date.today()))
+
+
+@cli.command()
+@click.argument("command")
+def bump_from_command(command: str) -> None:
+    """Execute the given command and then bump the result. Must output to JSON array of values"""
+    cmd_output = subprocess.run(shlex.split(command), timeout=5, capture_output=True, text=True)
+    current_version = max(map(Version, cmd_output.stdout.splitlines()))
+    click.echo(next_version(current_version, date.today()))
 
 
 @cli.command()

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           # Latest release in the repo; the bump script computes the next one.
           latest_versions=""
-          version="$(uv run --script .github/scripts/publish_prerelease.py bump-from \"gh release list --json name --jq '.[].name'\")"
+          version=$(uv run --script .github/scripts/publish_prerelease.py bump-from "gh release list --json name --jq '.[].name'")
           echo "Next Version: $version" >> "$GITHUB_OUTPUT"
 
           if [ "$DRY_RUN" = "true" ]; then

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -42,7 +42,7 @@ jobs:
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
         run: |
           # Latest release in the repo; the bump script computes the next one.
-          latest_versions = gh release list --json name --jq '.[].name'
+          latest_versions = "gh release list --json name --jq '.[].name'"
           version="$(uv run --script .github/scripts/publish_prerelease.py bump-from $latest_versions)"
           echo "Next Version: $version" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -42,8 +42,8 @@ jobs:
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
         run: |
           # Latest release in the repo; the bump script computes the next one.
-          latest_versions="gh release list --json name --jq '.[].name'"
-          version="$(uv run --script .github/scripts/publish_prerelease.py bump-from $latest_versions)"
+          latest_versions=""
+          version="$(uv run --script .github/scripts/publish_prerelease.py bump-from \"gh release list --json name --jq '.[].name'\")"
           echo "Next Version: $version" >> "$GITHUB_OUTPUT"
 
           if [ "$DRY_RUN" = "true" ]; then

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -13,6 +13,7 @@ on:
 permissions:
   contents: write
   actions: write
+  id-token: write
 
 concurrency:
   group: release-publish

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -42,7 +42,7 @@ jobs:
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
         run: |
           # Latest release in the repo; the bump script computes the next one.
-          latest_versions = "$(gh release list --json name --jq '.[].name')"
+          latest_versions = gh release list --json name --jq '.[].name'
           version="$(uv run --script .github/scripts/publish_prerelease.py bump-from $latest_versions)"
           echo "Next Version: $version" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -11,8 +11,8 @@ on:
         default: true
 
 permissions:
-  contents: write
-  actions: write
+  contents: write # gives access to apply the tag
+  actions: write # permission to run the workflow for publish
 
 concurrency:
   group: release-publish
@@ -42,7 +42,6 @@ jobs:
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
         run: |
           # Latest release in the repo; the bump script computes the next one.
-          latest_versions=""
           version=$(uv run --script .github/scripts/publish_prerelease.py bump-from "gh release list --json name --jq '.[].name'")
           echo "Next Version: $version"
 

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 concurrency:
   group: release-publish

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -13,7 +13,6 @@ on:
 permissions:
   contents: write
   actions: write
-  id-token: write
 
 concurrency:
   group: release-publish
@@ -51,4 +50,5 @@ jobs:
             echo "DRY RUN — Next Version would be: $version"
           else
             gh release create "$version" --prerelease --generate-notes --title "$version"
+            gh workflow run publish.yml --ref "$version"
           fi

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -42,15 +42,12 @@ jobs:
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
         run: |
           # Latest release in the repo; the bump script computes the next one.
-          latest="$(gh release list --json name --jq '.[].name' \
-            | grep -E '^[0-9]{4}\.[0-9]+\.[0-9]+([ab][0-9]+)?$' \
-            | sort -V | tail -1)"
-          version="$(uv run --script .github/scripts/publish_prerelease.py bump "$latest")"
-          echo "Latest tag: $latest -> next: $version"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
+          latest_versions = "$(gh release list --json name --jq '.[].name')"
+          version="$(uv run --script .github/scripts/publish_prerelease.py bump-from $latest_versions)"
+          echo "Next Version: $version" >> "$GITHUB_OUTPUT"
 
           if [ "$DRY_RUN" = "true" ]; then
-            echo "DRY RUN — would publish $version"
+            echo "DRY RUN — Next Version would be: $version"
           else
             gh release create "$version" --prerelease --generate-notes --title "$version"
           fi

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -44,7 +44,7 @@ jobs:
           # Latest release in the repo; the bump script computes the next one.
           latest_versions=""
           version=$(uv run --script .github/scripts/publish_prerelease.py bump-from "gh release list --json name --jq '.[].name'")
-          echo "Next Version: $version" >> "$GITHUB_OUTPUT"
+          echo "Next Version: $version"
 
           if [ "$DRY_RUN" = "true" ]; then
             echo "DRY RUN — Next Version would be: $version"

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -53,5 +53,4 @@ jobs:
             echo "DRY RUN — would publish $version"
           else
             gh release create "$version" --prerelease --generate-notes --title "$version"
-            gh workflow run publish.yml --ref "$version"
           fi

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -42,7 +42,7 @@ jobs:
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
         run: |
           # Latest release in the repo; the bump script computes the next one.
-          latest_versions = "gh release list --json name --jq '.[].name'"
+          latest_versions="gh release list --json name --jq '.[].name'"
           version="$(uv run --script .github/scripts/publish_prerelease.py bump-from $latest_versions)"
           echo "Next Version: $version" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
- **update permissions**
- **remoce manual PR call**
- **add bump_from**
- **update output to read new bump-from**
- **fix: latest_versions shell call**
- **fix: runs command inside of python script**
- **fix: remove spaces in shell**
- **fix:inline command**
- **fix: removes extra quotes**
- **remove: output export**
- **add: id-token: write**
- **add: re-add the publish workflow command**

<!--
SUMMARY OF THE CHANGES BEING MADE
Be sure to include any referenced issues and discussions.

Not following this guideline will result in the immediate rejection of your PR.
-->

Fixes the label prerelease in by

creating bump-from which takes a cmd (that must return a line-separated list of versions) and parses each version to get the Python-recognized latest)

#### Type of Issue

- [X] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [X] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [ ] YES - Changes have been documented

#### Changes have been Tested

- [X] YES - Changes have been tested - 2026.6.2a3  generated this way

#### Next Steps

- [X] we can likely remove the tests from the publish script and the merge script since all commits are tested via PR (although I'd like clarification on that)
<!--ANY FURTHER STEPS TO BE TAKEN-->

#### AI Attestation

Some AI was used in helping troubleshoot script commands
<!-- Include how AI was used in the creation of this change -->
