### PR TITLE
Audit lint.yml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,20 +4,23 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 jobs:
   lint-python:
     name: Format and Lint Python
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 0
+          persist-credentials: false
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           python-version: 3.14
       - name: Install dependencies
@@ -29,8 +32,10 @@ jobs:
     name: Lint Markdown
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: lint-test
-        uses: DavidAnson/markdownlint-cli2-action@v23
+        uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd # v23.2.0
         with:
           globs: '**/*.md'


### PR DESCRIPTION
Audit of lint.yml yieled the following result

- pinned deps using pinact
- removed: `fetch-depth`
- adds: `persist-credentials: false`


### Why remove fetch-depth:

it seems like this was a leftover from when we were letting actions modify content


### Why persist-credentials:

removes secrets loading per - https://yossarian.net/til/post/actions-checkout-can-leak-github-credentials/

<!--
SUMMARY OF THE CHANGES BEING MADE
Be sure to include any referenced issues and discussions.

Not following this guideline will result in the immediate rejection of your PR.
-->

#### Type of Issue

- [ ] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [X] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [ ] YES - Changes have been documented

#### Changes have been Tested

- [X] YES - Changes have been tested

passes all zizmor checks

#### Next Steps

<!--ANY FURTHER STEPS TO BE TAKEN-->

#### AI Attestation

AI was used as justification on if fetch-depth was necessary

<!-- Include how AI was used in the creation of this change -->
