### PR TITLE
Added the static site-map

### DIFF
--- a/docs/docs/site_map.md
+++ b/docs/docs/site_map.md
@@ -61,6 +61,37 @@ To have your site generate an XML site map set the `render_xml_site_map` propert
 to `True` (defaults to `False`.) This will create the `site_map.xml` file in the root output directory
 of your site.
 
+## Including Static Files in the Site Map
+
+By default, the `SiteMap` also includes an entry for every static file found in
+the `Site`'s `static_paths` (e.g. images, CSS, JS, and any other files copied
+from your static directories). This means static assets show up in both the
+generated HTML site map and the XML site map alongside your `Page` and
+`Collection` entries.
+
+Static file entries use the URL they are ultimately served at, based on where
+`static_paths` are copied to in the output directory. For example, a file at
+`static/images/logo.png` will appear in the site map with the URL
+`/static/images/logo.png`.
+
+If you want to add static files to a `SiteMap` manually — for example, when
+working with the `SiteMap` object directly rather than through `Site.render()`
+— use the `add_static_files` method:
+
+```python
+def add_static_files(self, static_paths: Iterable[str | Path]) -> None:
+```
+
+### Parameters
+
+- `static_paths`: An iterable of directories (as `str` or `Path`) to walk for
+  static files. This is normally `Site.static_paths`, the same set of
+  directories copied to the output folder.
+
+Note: `SiteMap.update()` will automatically call `add_static_files` for you
+if the `SiteMap` has `static_paths` set, so in most cases you won't need to
+call this directly — it happens automatically as part of `Site.render()`.
+
 ## The `SiteMapEntry` object
 
 The `SiteMap` is a collection of `SiteMapEntry` objects. Each `SiteMapEntry` has the following attributes
@@ -74,3 +105,24 @@ and properties:
 - `entries` - A list of `SiteMapEntry` objects representing the `Page` objects in a given `Collection`.
 for a `Page` this will be an empty `list`.
 - `url_for` - This property will provide the _relative_ URL for the given entry.
+
+## The `StaticSiteMapEntry` object
+
+`StaticSiteMapEntry` is a subclass of `SiteMapEntry` used to represent static
+files (images, CSS, JS, etc.) in the site map, rather than `Page` or
+`Collection` objects. It shares the same `url_for` property and `__str__`
+behavior as `SiteMapEntry`, so it can be used interchangeably anywhere a
+`SiteMapEntry` is expected — for example, when iterating over a `SiteMap` or
+using `SiteMap.find()`.
+
+### Attributes and Properties
+
+- `slug` - A slug generated from the static file's path relative to its
+  static directory (e.g. `static-images-logo-png`).
+- `title` - The file's name (e.g. `logo.png`).
+- `path_name` - The file's path relative to its static directory (e.g.
+  `images/logo.png`).
+- `entries` - Always an empty `list`, since a static file has no
+  sub-entries.
+- `url_for` - Inherited from `SiteMapEntry`. Returns the file's relative URL,
+  e.g. `/static/images/logo.png`.

--- a/docs/docs/site_map.md
+++ b/docs/docs/site_map.md
@@ -82,6 +82,7 @@ working with the `SiteMap` object directly rather than through `Site.render()`
 def add_static_files(self, static_paths: Iterable[str | Path]) -> None:
 ```
 
+<!--  markdownlint-disable-next-line MD024 -->
 ### Parameters
 
 - `static_paths`: An iterable of directories (as `str` or `Path`) to walk for
@@ -114,15 +115,3 @@ files (images, CSS, JS, etc.) in the site map, rather than `Page` or
 behavior as `SiteMapEntry`, so it can be used interchangeably anywhere a
 `SiteMapEntry` is expected — for example, when iterating over a `SiteMap` or
 using `SiteMap.find()`.
-
-### Attributes and Properties
-
-- `slug` - A slug generated from the static file's path relative to its
-  static directory (e.g. `static-images-logo-png`).
-- `title` - The file's name (e.g. `logo.png`).
-- `path_name` - The file's path relative to its static directory (e.g.
-  `images/logo.png`).
-- `entries` - Always an empty `list`, since a static file has no
-  sub-entries.
-- `url_for` - Inherited from `SiteMapEntry`. Returns the file's relative URL,
-  e.g. `/static/images/logo.png`.

--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -86,10 +86,13 @@ class Site:
         # for these attributes
         template_path = getattr(self, "_template_path", template_path)
         output_path = getattr(self, "_output_path", output_path)
-        static_paths = getattr(
-            self,
-            "_static_paths",
-            {"static"} if static_paths is SENTINEL else static_paths,
+        static_paths = cast(
+            "set[str | Path]",
+            getattr(
+                self,
+                "_static_paths",
+                {"static"} if static_paths is SENTINEL else static_paths,
+            ),
         )
         self.plugin_settings: dict = cast(
             dict,

--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -59,7 +59,7 @@ class Site:
         *,
         output_path: str | Path = "output",
         template_path: str | Path = "templates",
-        static_paths: set[str | Path] = {"static"},
+        static_paths: set[str | Path] | object = SENTINEL,
         plugin_settings: object | dict = SENTINEL,
         render_html_site_map: bool = False,
         render_xml_site_map: bool = False,
@@ -86,7 +86,11 @@ class Site:
         # for these attributes
         template_path = getattr(self, "_template_path", template_path)
         output_path = getattr(self, "_output_path", output_path)
-        static_paths = getattr(self, "_static_paths", static_paths)
+        static_paths = getattr(
+            self,
+            "_static_paths",
+            {"static"} if static_paths is SENTINEL else static_paths,
+        ) 
         self.plugin_settings: dict = cast(
             dict,
             getattr(
@@ -390,8 +394,8 @@ class Site:
             # to https://localhost:8000/ This task will update to the correct site URL and with the route list
             # as it will be rendered.
             self._site_map.site_url = site_url
+            self._site_map.static_paths = self.static_paths
             self._site_map.update(self.route_list)
-            self._site_map.add_static_files(self.static_paths)
 
             if self.render_html_site_map:
 

--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -90,7 +90,7 @@ class Site:
             self,
             "_static_paths",
             {"static"} if static_paths is SENTINEL else static_paths,
-        ) 
+        )
         self.plugin_settings: dict = cast(
             dict,
             getattr(

--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -391,6 +391,7 @@ class Site:
             # as it will be rendered.
             self._site_map.site_url = site_url
             self._site_map.update(self.route_list)
+            self._site_map.add_static_files(self.static_paths)
 
             if self.render_html_site_map:
 

--- a/src/render_engine/site_map.py
+++ b/src/render_engine/site_map.py
@@ -42,9 +42,10 @@ class SiteMapEntry:
     def __str__(self) -> str:
         """String representation of the entry as its URL"""
         return self.url_for
-    
-class StaticSiteMapEntry:
-    """Site map entry for a static file """
+
+
+class StaticSiteMapEntry(SiteMapEntry):
+    """Site map entry for a static file"""
 
     def __init__(self, file_path: Path, static_root: Path, url_prefix: str = ""):
         """
@@ -62,29 +63,27 @@ class StaticSiteMapEntry:
         self._route = f"/{prefix}/{relative}" if prefix else f"/{relative}"
         self.entries: list = []
 
-    @property
-    def url_for(self) -> str:
-        """The URL for the given entry"""
-        return str(self._route)
-
-    def __str__(self) -> str:
-        """String representation of the entry as its URL"""
-        return self.url_for
-
 
 class SiteMap:
     """Site map"""
 
-    def __init__(self, site_url: str = "", route_list: dict | None = None) -> None:
+    def __init__(
+        self,
+        site_url: str = "",
+        route_list: dict | None = None,
+        static_paths: Iterable[str | Path] | None = None,
+    ) -> None:
         """
         Create the site map based on the route_list
 
         :param site_url: Used for rendering the HTML to have absolute URLs.
         :param route_list: The route list to parse
+        :param static_paths: Static directories to include in the site map
         """
         self._route_map = dict()
         self._collections = dict()
         self._site_url = site_url
+        self.static_paths = static_paths
         if not route_list:
             return
         self.update(route_list)
@@ -113,6 +112,20 @@ class SiteMap:
             self._route_map[sm_entry.slug] = sm_entry
             if sm_entry.entries:
                 self._collections[sm_entry.slug] = sm_entry
+        if self.static_paths:
+            self.add_static_files(self.static_paths)
+
+    def add_static_files(self, static_paths: Iterable[str | Path]) -> None:
+        """Add static files to the site map"""
+        for static in static_paths:
+            static = Path(static)
+            if not static.exists():
+                continue
+            url_prefix = static.name
+            for file_path in static.rglob("*"):
+                if file_path.is_file():
+                    entry = StaticSiteMapEntry(file_path, static, url_prefix)
+                    self._route_map[entry.slug] = entry
 
     def __iter__(self) -> Generator[SiteMapEntry]:
         """Iterator for the site map object"""
@@ -178,20 +191,7 @@ class SiteMap:
                 if entry := search(attr, value, collection.entries):
                     return entry
         return None
-    
-    def add_static_files(self, static_paths: Iterable[str | Path]) -> None:
-        """ Add static files to the site map"""
-        for static in static_paths:
-            static = Path(static)
-            if not static.exists():
-                continue
-            url_prefix = static.name
-            for file_path in static.rglob("*"):
-                if file_path.is_file():
-                    entry = StaticSiteMapEntry(file_path, static, url_prefix)
-                    self._route_map[entry.slug] = entry
-        
-    
+
     @property
     def html(self) -> str:
         """Build the site map as HTML"""

--- a/src/render_engine/site_map.py
+++ b/src/render_engine/site_map.py
@@ -42,6 +42,34 @@ class SiteMapEntry:
     def __str__(self) -> str:
         """String representation of the entry as its URL"""
         return self.url_for
+    
+class StaticSiteMapEntry:
+    """Site map entry for a static file """
+
+    def __init__(self, file_path: Path, static_root: Path, url_prefix: str = ""):
+        """
+        :param file_path: Absolute path to the static file on disk.
+        :param static_root: The static directory this file lives under (e.g. "static").
+        :param url_prefix: The folder name this static dir gets copied to in the
+            output directory. `ThemeManager._render_static` copies each static_path
+            to `output_path / static_path.name`, so this should be `static_root.name`.
+        """
+        relative = file_path.relative_to(static_root).as_posix()
+        self.slug = slugify.slugify(f"{url_prefix}/{relative}" if url_prefix else relative)
+        self.title = file_path.name
+        self.path_name = relative
+        prefix = url_prefix.strip("/")
+        self._route = f"/{prefix}/{relative}" if prefix else f"/{relative}"
+        self.entries: list = []
+
+    @property
+    def url_for(self) -> str:
+        """The URL for the given entry"""
+        return str(self._route)
+
+    def __str__(self) -> str:
+        """String representation of the entry as its URL"""
+        return self.url_for
 
 
 class SiteMap:
@@ -150,7 +178,20 @@ class SiteMap:
                 if entry := search(attr, value, collection.entries):
                     return entry
         return None
-
+    
+    def add_static_files(self, static_paths: Iterable[str | Path]) -> None:
+        """ Add static files to the site map"""
+        for static in static_paths:
+            static = Path(static)
+            if not static.exists():
+                continue
+            url_prefix = static.name
+            for file_path in static.rglob("*"):
+                if file_path.is_file():
+                    entry = StaticSiteMapEntry(file_path, static, url_prefix)
+                    self._route_map[entry.slug] = entry
+        
+    
     @property
     def html(self) -> str:
         """Build the site map as HTML"""

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -467,6 +467,7 @@ def test_site_constructor_sub_class():
     for attr, value in expected_attrs.items():
         assert getattr(site, attr) == value, f"Failure at {attr}"
 
+
 def test_static_files_appear_in_site_map_after_render(tmp_path: Path):
     """Static files should be included in site.site_map once the site has been rendered"""
     static_dir = tmp_path / "static"

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -466,3 +466,64 @@ def test_site_constructor_sub_class():
 
     for attr, value in expected_attrs.items():
         assert getattr(site, attr) == value, f"Failure at {attr}"
+
+def test_static_files_appear_in_site_map_after_render(tmp_path: Path):
+    """Static files should be included in site.site_map once the site has been rendered"""
+    static_dir = tmp_path / "static"
+    static_dir.mkdir()
+    (static_dir / "logo.png").write_text("fake-image-bytes")
+
+    site = Site()
+    site.output_path = tmp_path / "output"
+    site.static_paths.add(static_dir)
+
+    @site.page
+    class CustomPage(Page):
+        content = "this is a test"
+
+    site.render()
+
+    entry = site.site_map.find("/static/logo.png", attr="url_for")
+    assert entry is not None
+    assert entry.title == "logo.png"
+
+
+def test_static_files_appear_in_xml_site_map(tmp_path: Path):
+    """Rendered site_map.xml should include a <url> entry for static files"""
+    static_dir = tmp_path / "static"
+    static_dir.mkdir()
+    (static_dir / "logo.png").write_text("fake-image-bytes")
+
+    site = Site()
+    site.output_path = tmp_path / "output"
+    site.static_paths.add(static_dir)
+    site.render_xml_site_map = True
+
+    @site.page
+    class CustomPage(Page):
+        content = "this is a test"
+
+    site.render()
+
+    xml_content = (site.output_path / "site_map.xml").read_text()
+    assert "http://localhost:8000/static/logo.png" in xml_content
+
+
+def test_nested_static_files_appear_in_site_map(tmp_path: Path):
+    """Nested static files (subfolders) should also get their own site map entry"""
+    static_dir = tmp_path / "static"
+    (static_dir / "nested").mkdir(parents=True)
+    (static_dir / "nested" / "test.txt").write_text("test")
+
+    site = Site()
+    site.output_path = tmp_path / "output"
+    site.static_paths.add(static_dir)
+
+    @site.page
+    class CustomPage(Page):
+        content = "this is a test"
+
+    site.render()
+
+    entry = site.site_map.find("/static/nested/test.txt", attr="url_for")
+    assert entry is not None

--- a/tests/test_site_map.py
+++ b/tests/test_site_map.py
@@ -5,7 +5,7 @@ import pytest
 from render_engine.collection import Collection
 from render_engine.page import Page
 from render_engine.site import Site
-from render_engine.site_map import SiteMap, SiteMapEntry
+from render_engine.site_map import SiteMap, SiteMapEntry , StaticSiteMapEntry
 
 PAGE_TEMPLATE = """
 ---
@@ -190,3 +190,62 @@ def test_site_map_to_xml(site):
 </url>
 </urlset>"""
     )
+
+def test_static_site_map_entry_attributes(tmp_path):
+    static_dir = tmp_path / "static"
+    (static_dir / "css").mkdir(parents=True)
+    file_path = static_dir / "css" / "main.css"
+    file_path.write_text("body { color: red; }")
+
+    entry = StaticSiteMapEntry(file_path, static_dir, url_prefix="static")
+
+    assert entry.path_name == "css/main.css"
+    assert entry.title == "main.css"
+    assert entry.url_for == "/static/css/main.css"
+    assert entry.entries == []
+    assert str(entry) == entry.url_for
+
+
+def test_add_static_files_adds_entry_per_file(tmp_path):
+    static_dir = tmp_path / "static"
+    (static_dir / "images").mkdir(parents=True)
+    (static_dir / "style.css").write_text("body{}")
+    (static_dir / "images" / "logo.png").write_text("fake-png-bytes")
+
+    sm = SiteMap("http://example.com")
+    sm.add_static_files([static_dir])
+
+    urls = sorted(entry.url_for for entry in sm)
+    assert urls == ["/static/images/logo.png", "/static/style.css"]
+
+
+
+
+
+def test_add_static_files_multiple_static_dirs_no_collision(tmp_path):
+    static_dir_1 = tmp_path / "static"
+    static_dir_2 = tmp_path / "theme_static"
+    static_dir_1.mkdir()
+    static_dir_2.mkdir()
+    (static_dir_1 / "logo.png").write_text("a")
+    (static_dir_2 / "logo.png").write_text("b")
+
+    sm = SiteMap("http://example.com")
+    sm.add_static_files([static_dir_1, static_dir_2])
+
+    urls = sorted(entry.url_for for entry in sm)
+    assert urls == ["/static/logo.png", "/theme_static/logo.png"]
+
+
+def test_add_static_files_can_be_found_via_site_map_find(tmp_path):
+    static_dir = tmp_path / "static"
+    static_dir.mkdir()
+    (static_dir / "logo.png").write_text("fake-png-bytes")
+
+    sm = SiteMap("http://example.com")
+    sm.add_static_files([static_dir])
+
+    found = sm.find("/static/logo.png", attr="url_for")
+    assert found is not None
+    assert found.title == "logo.png"
+    assert sm.find("/static/missing.png", attr="url_for") is None

--- a/tests/test_site_map.py
+++ b/tests/test_site_map.py
@@ -5,7 +5,7 @@ import pytest
 from render_engine.collection import Collection
 from render_engine.page import Page
 from render_engine.site import Site
-from render_engine.site_map import SiteMap, SiteMapEntry , StaticSiteMapEntry
+from render_engine.site_map import SiteMap, SiteMapEntry, StaticSiteMapEntry
 
 PAGE_TEMPLATE = """
 ---
@@ -191,6 +191,7 @@ def test_site_map_to_xml(site):
 </urlset>"""
     )
 
+
 def test_static_site_map_entry_attributes(tmp_path):
     static_dir = tmp_path / "static"
     (static_dir / "css").mkdir(parents=True)
@@ -217,9 +218,6 @@ def test_add_static_files_adds_entry_per_file(tmp_path):
 
     urls = sorted(entry.url_for for entry in sm)
     assert urls == ["/static/images/logo.png", "/static/style.css"]
-
-
-
 
 
 def test_add_static_files_multiple_static_dirs_no_collision(tmp_path):


### PR DESCRIPTION
Fixes #986
The issue was that  Site.render() only ever builds the site map from self.route_list . Static path does not pass through this path  they r just copied at output folder using ThemeManager._render_static()
so they never get into sitemap

__>So changes are made in site_map.py :- i made add a StaticSiteMapEntry class which have the same attribute as SiteMapEntry than added add add_static_file function in  static map 
__> Add one line in site.py :- which stores satic file in routes
__> add some new test cases to test out these feature and they r working perfectly fine 

-->

#### Type of Issue


- [ ] :dizzy: (New Feature) issue no.:_986 
-
#### Changes have been Documented (If Applicable)

- [ ] YEs - Changes have been documented

#### Changes have been Tested

- [ ] YES - Changes have been tested


#### AI Attestation
Ai is use to analyse the pre existing code base
