### PR TITLE
Update permissions for labeler.yml

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   labeler:


### PR DESCRIPTION
Fixes permissions issue with `labeler.yml`

Per [documentation](https://docs.github.com/en/rest/issues/labels?apiVersion=2026-03-10#set-labels-for-an-issue) `issues: write` permission is needed for this workflow and was mistakenly removed during the audit.

#### Type of Issue

- [x] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [ ] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [ ] YES - Changes have been documented
NA

#### Changes have been Tested

- [ ] YES - Changes have been tested
NA

#### Next Steps

Pray that it works.

#### AI Attestation

No AI has been used in the creation of this PR.