### PR TITLE
Add include/exclude filtering for static site map entries (#1233)

### DIFF
--- a/docs/docs/site.md
+++ b/docs/docs/site.md
@@ -40,6 +40,11 @@ Site(
     render_xml_site_map: bool = False,
     slug_only_urls: bool = False,
     site_vars: object | dict = SENTINEL,
+    static_include_patterns: set[str] | None = None,
+    static_exclude_patterns: set[str] | None = None,
+    static_exclude_dirs: set[str] | None = None,
+    static_include_dirs: set[str] | None = None,
+    include_static_in_site_map: bool = False,
 ) -> None:
     pass
 ```
@@ -58,6 +63,11 @@ The `Site` constructor takes the following keyword arguments:
 | `render_xml_site_map`  | `bool`       | When True render the site map as an XML file. Default: False.                            |
 | `slug_only_urls`       | `bool`       | Default value for Page objects rendering slub only URLS. Default: False                  |
 | `site_vars`            | `dict`       | The site_vars dictionary containing data to be passed to all templates during rendering. |
+| `static_include_patterns` | `set[str] \| None` | Glob patterns a static file must match to be included. Default: `None` (no filtering). |
+| `static_exclude_patterns` | `set[str] \| None` | Glob patterns that exclude a static file even if it matched an include pattern. Default: `None`. |
+| `static_exclude_dirs`  | `set[str] \| None` | Directory names to skip entirely under any static path. Default: `None`. |
+| `static_include_dirs`  | `set[str] \| None` | Subdirectory paths that override `static_exclude_dirs` for matching subdirectories. Default: `None`. |
+| `include_static_in_site_map` | `bool` | When True, static files are added to the site map. Default: `False`. |
 <!-- markdownlint-enable MD056 -->
 <!-- markdownlint-enable MD060 -->
 

--- a/docs/docs/site_map.md
+++ b/docs/docs/site_map.md
@@ -95,25 +95,34 @@ def add_static_files(
   static files. This is normally `Site.static_paths`, the same set of
   directories copied to the output folder.
 - `include_patterns`: An iterable of glob patterns a file must match to be
-  included in the site map. Defaults to `("*",)`, which includes every file.
+  included in the site map. Defaults to `None`, meaning no filtering — every
+  file is included.
 - `exclude_patterns`: An iterable of glob patterns that exclude a file even
-  if it matched an `include_patterns` entry. Defaults to `()`, excluding
+  if it matched an `include_patterns` entry. Defaults to `None`, excluding
   nothing.
 - `exclude_dirs`: An iterable of directory names to skip entirely, matched
   against any path segment relative to the static directory. Defaults to
-  `()`, excluding nothing.
+  `None`, excluding nothing.
+- `include_dirs`: An iterable of subdirectory paths that override
+  `exclude_dirs`, forcing inclusion for matching subdirectories even if a
+  parent directory was excluded. Defaults to `None`.
 
 Note: `SiteMap.update()` will automatically call `add_static_files` for you
-if the `SiteMap` has `static_paths` set, using `Site.static_include_patterns`,
-`Site.static_exclude_patterns`, and `Site.static_exclude_dirs` — so in most
-cases you won't need to call this directly, or configure filtering anywhere
-except on your `Site` object. For example:
+if the `SiteMap` has `static_paths` set and `include_static_in_site_map` is
+`True`, using `Site.static_include_patterns`, `Site.static_exclude_patterns`,
+`Site.static_exclude_dirs`, and `Site.static_include_dirs` — so in most cases
+you won't need to call this directly, or configure filtering anywhere except
+on your `Site` object. Setting `include_static_in_site_map=False` on `Site`
+excludes static files from the site map entirely, without affecting whether
+they are copied to the output directory. For example:
 
 ```python
 site = Site(
     static_paths={"static"},
     static_include_patterns=("*.css", "*.js", "*.png"),
     static_exclude_dirs=("drafts",),
+    static_include_dirs=("drafts/public",),
+    include_static_in_site_map=True,
 )
 ```
 

--- a/docs/docs/site_map.md
+++ b/docs/docs/site_map.md
@@ -82,9 +82,10 @@ working with the `SiteMap` object directly rather than through `Site.render()`
 def add_static_files(
     self,
     static_paths: Iterable[str | Path],
-    include_patterns: Iterable[str] = ("*",),
-    exclude_patterns: Iterable[str] = (),
-    exclude_dirs: Iterable[str] = (),
+    include_patterns: Iterable[str] | None = None,
+    exclude_patterns: Iterable[str] | None = None,
+    exclude_dirs: Iterable[str] | None = None,
+    include_dirs: Iterable[str] | None = None,
 ) -> None:
 ```
 

--- a/docs/docs/site_map.md
+++ b/docs/docs/site_map.md
@@ -106,7 +106,7 @@ def add_static_files(
   `None`, excluding nothing.
 - `include_dirs`: An iterable of subdirectory paths that override
   `exclude_dirs`, forcing inclusion for matching subdirectories even if a
-  parent directory was excluded. Defaults to `None`.
+  parent directory was excluded. Defaults to `None`, meaning no override.
 
 Note: `SiteMap.update()` will automatically call `add_static_files` for you
 if the `SiteMap` has `static_paths` set and `include_static_in_site_map` is

--- a/docs/docs/site_map.md
+++ b/docs/docs/site_map.md
@@ -79,7 +79,13 @@ working with the `SiteMap` object directly rather than through `Site.render()`
 — use the `add_static_files` method:
 
 ```python
-def add_static_files(self, static_paths: Iterable[str | Path]) -> None:
+def add_static_files(
+    self,
+    static_paths: Iterable[str | Path],
+    include_patterns: Iterable[str] = ("*",),
+    exclude_patterns: Iterable[str] = (),
+    exclude_dirs: Iterable[str] = (),
+) -> None:
 ```
 
 <!--  markdownlint-disable-next-line MD024 -->
@@ -88,10 +94,28 @@ def add_static_files(self, static_paths: Iterable[str | Path]) -> None:
 - `static_paths`: An iterable of directories (as `str` or `Path`) to walk for
   static files. This is normally `Site.static_paths`, the same set of
   directories copied to the output folder.
+- `include_patterns`: An iterable of glob patterns a file must match to be
+  included in the site map. Defaults to `("*",)`, which includes every file.
+- `exclude_patterns`: An iterable of glob patterns that exclude a file even
+  if it matched an `include_patterns` entry. Defaults to `()`, excluding
+  nothing.
+- `exclude_dirs`: An iterable of directory names to skip entirely, matched
+  against any path segment relative to the static directory. Defaults to
+  `()`, excluding nothing.
 
 Note: `SiteMap.update()` will automatically call `add_static_files` for you
-if the `SiteMap` has `static_paths` set, so in most cases you won't need to
-call this directly — it happens automatically as part of `Site.render()`.
+if the `SiteMap` has `static_paths` set, using `Site.static_include_patterns`,
+`Site.static_exclude_patterns`, and `Site.static_exclude_dirs` — so in most
+cases you won't need to call this directly, or configure filtering anywhere
+except on your `Site` object. For example:
+
+```python
+site = Site(
+    static_paths={"static"},
+    static_include_patterns=("*.css", "*.js", "*.png"),
+    static_exclude_dirs=("drafts",),
+)
+```
 
 ## The `SiteMapEntry` object
 

--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -2,6 +2,7 @@ import copy
 import json
 import logging
 from collections import defaultdict
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, cast
 
@@ -65,6 +66,9 @@ class Site:
         render_xml_site_map: bool = False,
         slug_only_urls: bool = False,
         site_vars: object | dict = SENTINEL,
+        static_include_patterns: Iterable[str] = ("*",),
+        static_exclude_patterns: Iterable[str] = (),
+        static_exclude_dirs: Iterable[str] = (),
     ) -> None:
         """
         Constructor for the Site object.
@@ -80,6 +84,9 @@ class Site:
         :param render_xml_site_map: When True render the site map as an XMK file. Default: False
         :param slug_only_urls: Default value for Page objects rendering slub only URLS. Default: False
         :param site_vars: The site_vars dictionary containing data to be passed to all templates during rendering
+        :param static_include_patterns: Glob patterns a static file must match to be included. Default: all files.
+        :param static_exclude_patterns: Glob patterns that exclude a static file even if it matched an include pattern.
+        :param static_exclude_dirs: Directory names to skip entirely under any static path.
         """
         # Use getattr for the attributes moved from class level to constructor arguments
         # to properly handle subclassing. This will prefeer the value from the subclass
@@ -94,6 +101,10 @@ class Site:
                 {"static"} if static_paths is SENTINEL else static_paths,
             ),
         )
+        self.static_include_patterns: Iterable[str] = getattr(self, "static_include_patterns", static_include_patterns)
+        self.static_exclude_patterns: Iterable[str] = getattr(self, "static_exclude_patterns", static_exclude_patterns)
+        self.static_exclude_dirs: Iterable[str] = getattr(self, "static_exclude_dirs", static_exclude_dirs)
+
         self.plugin_settings: dict = cast(
             dict,
             getattr(
@@ -398,6 +409,9 @@ class Site:
             # as it will be rendered.
             self._site_map.site_url = site_url
             self._site_map.static_paths = self.static_paths
+            self._site_map.static_include_patterns = self.static_include_patterns
+            self._site_map.static_exclude_patterns = self.static_exclude_patterns
+            self._site_map.static_exclude_dirs = self.static_exclude_dirs
             self._site_map.update(self.route_list)
 
             if self.render_html_site_map:

--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -70,7 +70,7 @@ class Site:
         static_exclude_patterns: Iterable[str] | None = None,
         static_exclude_dirs: Iterable[str] | None = None,
         static_include_dirs: Iterable[str] | None = None,
-        include_static_in_site_map: bool = True,
+        include_static_in_site_map: bool = False,
     ) -> None:
         """
         Constructor for the Site object.
@@ -81,18 +81,17 @@ class Site:
         :param output_path: Path to write rendered content
         :param template_path: Path to location of template files
         :param static_paths: Paths for static folders copied to output (recursive)
-        :param plugin_settings: Dictionary caontaining plugin settings
+        :param plugin_settings: Dictionary containing plugin settings
         :param render_html_site_map: When True render the site map as an HTML file. Default: False
         :param render_xml_site_map: When True render the site map as an XMK file. Default: False
         :param slug_only_urls: Default value for Page objects rendering slub only URLS. Default: False
         :param site_vars: The site_vars dictionary containing data to be passed to all templates during rendering
-        :param static_include_patterns: Glob patterns a static file must match to be included.
-            Default None: no filtering.
+        :param static_include_patterns: Glob patterns a static file must match to be included. Default: None.
         :param static_exclude_patterns: Glob patterns that exclude a static file even if it matched an include pattern.
         :param static_exclude_dirs: Directory names to skip entirely under any static path.
         :param static_include_dirs: Subdirectory paths that override static_exclude_dirs for matching subdirectories.
-        :param include_static_in_site_map: When False, static files are not added to the site map at all
-            (they are still copied to output). Default: True.
+        :param include_static_in_site_map: When True, static files are added to the site map.
+            They are always copied to output regardless of this setting. Default: False.
         """
         # Use getattr for the attributes moved from class level to constructor arguments
         # to properly handle subclassing. This will prefeer the value from the subclass

--- a/src/render_engine/site.py
+++ b/src/render_engine/site.py
@@ -66,9 +66,11 @@ class Site:
         render_xml_site_map: bool = False,
         slug_only_urls: bool = False,
         site_vars: object | dict = SENTINEL,
-        static_include_patterns: Iterable[str] = ("*",),
-        static_exclude_patterns: Iterable[str] = (),
-        static_exclude_dirs: Iterable[str] = (),
+        static_include_patterns: Iterable[str] | None = None,
+        static_exclude_patterns: Iterable[str] | None = None,
+        static_exclude_dirs: Iterable[str] | None = None,
+        static_include_dirs: Iterable[str] | None = None,
+        include_static_in_site_map: bool = True,
     ) -> None:
         """
         Constructor for the Site object.
@@ -84,9 +86,13 @@ class Site:
         :param render_xml_site_map: When True render the site map as an XMK file. Default: False
         :param slug_only_urls: Default value for Page objects rendering slub only URLS. Default: False
         :param site_vars: The site_vars dictionary containing data to be passed to all templates during rendering
-        :param static_include_patterns: Glob patterns a static file must match to be included. Default: all files.
+        :param static_include_patterns: Glob patterns a static file must match to be included.
+            Default None: no filtering.
         :param static_exclude_patterns: Glob patterns that exclude a static file even if it matched an include pattern.
         :param static_exclude_dirs: Directory names to skip entirely under any static path.
+        :param static_include_dirs: Subdirectory paths that override static_exclude_dirs for matching subdirectories.
+        :param include_static_in_site_map: When False, static files are not added to the site map at all
+            (they are still copied to output). Default: True.
         """
         # Use getattr for the attributes moved from class level to constructor arguments
         # to properly handle subclassing. This will prefeer the value from the subclass
@@ -101,9 +107,15 @@ class Site:
                 {"static"} if static_paths is SENTINEL else static_paths,
             ),
         )
-        self.static_include_patterns: Iterable[str] = getattr(self, "static_include_patterns", static_include_patterns)
-        self.static_exclude_patterns: Iterable[str] = getattr(self, "static_exclude_patterns", static_exclude_patterns)
-        self.static_exclude_dirs: Iterable[str] = getattr(self, "static_exclude_dirs", static_exclude_dirs)
+        self.static_include_patterns: Iterable[str] | None = getattr(
+            self, "static_include_patterns", static_include_patterns
+        )
+        self.static_exclude_patterns: Iterable[str] | None = getattr(
+            self, "static_exclude_patterns", static_exclude_patterns
+        )
+        self.static_exclude_dirs: Iterable[str] | None = getattr(self, "static_exclude_dirs", static_exclude_dirs)
+        self.static_include_dirs: Iterable[str] | None = getattr(self, "static_include_dirs", static_include_dirs)
+        self.include_static_in_site_map: bool = getattr(self, "include_static_in_site_map", include_static_in_site_map)
 
         self.plugin_settings: dict = cast(
             dict,
@@ -412,6 +424,8 @@ class Site:
             self._site_map.static_include_patterns = self.static_include_patterns
             self._site_map.static_exclude_patterns = self.static_exclude_patterns
             self._site_map.static_exclude_dirs = self.static_exclude_dirs
+            self._site_map.static_include_dirs = self.static_include_dirs
+            self._site_map.include_static_in_site_map = self.include_static_in_site_map
             self._site_map.update(self.route_list)
 
             if self.render_html_site_map:

--- a/src/render_engine/site_map.py
+++ b/src/render_engine/site_map.py
@@ -84,6 +84,9 @@ class SiteMap:
         self._collections = dict()
         self._site_url = site_url
         self.static_paths = static_paths
+        self.static_include_patterns: Iterable[str] = ("*",)
+        self.static_exclude_patterns: Iterable[str] = ()
+        self.static_exclude_dirs: Iterable[str] = ()
         if not route_list:
             return
         self.update(route_list)
@@ -113,19 +116,45 @@ class SiteMap:
             if sm_entry.entries:
                 self._collections[sm_entry.slug] = sm_entry
         if self.static_paths:
-            self.add_static_files(self.static_paths)
+            self.add_static_files(
+                self.static_paths,
+                include_patterns=self.static_include_patterns,
+                exclude_patterns=self.static_exclude_patterns,
+                exclude_dirs=self.static_exclude_dirs,
+            )
 
-    def add_static_files(self, static_paths: Iterable[str | Path]) -> None:
-        """Add static files to the site map"""
+    def add_static_files(
+        self,
+        static_paths: Iterable[str | Path],
+        include_patterns: Iterable[str] = ("*",),
+        exclude_patterns: Iterable[str] = (),
+        exclude_dirs: Iterable[str] = (),
+    ) -> None:
+        """
+        Add static files to the site map, optionally filtered by pattern or directory.
+
+        :param static_paths: Static directories to include in the site map
+        :param include_patterns: Glob patterns a file must match to be included. Defaults to all files.
+        :param exclude_patterns: Glob patterns that exclude a matching file even if it matched an include pattern.
+        :param exclude_dirs: Directory names to skip entirely (matched against any path segment).
+        """
         for static in static_paths:
             static = Path(static)
             if not static.exists():
                 continue
             url_prefix = static.name
             for file_path in static.rglob("*"):
-                if file_path.is_file():
-                    entry = StaticSiteMapEntry(file_path, static, url_prefix)
-                    self._route_map[entry.slug] = entry
+                if not file_path.is_file():
+                    continue
+                rel_parts = file_path.relative_to(static).parts[:-1]
+                if exclude_dirs and any(part in exclude_dirs for part in rel_parts):
+                    continue
+                if not any(file_path.match(p) for p in include_patterns):
+                    continue
+                if exclude_patterns and any(file_path.match(p) for p in exclude_patterns):
+                    continue
+                entry = StaticSiteMapEntry(file_path, static, url_prefix)
+                self._route_map[entry.slug] = entry
 
     def __iter__(self) -> Generator[SiteMapEntry]:
         """Iterator for the site map object"""

--- a/src/render_engine/site_map.py
+++ b/src/render_engine/site_map.py
@@ -84,9 +84,11 @@ class SiteMap:
         self._collections = dict()
         self._site_url = site_url
         self.static_paths = static_paths
-        self.static_include_patterns: Iterable[str] = ("*",)
-        self.static_exclude_patterns: Iterable[str] = ()
-        self.static_exclude_dirs: Iterable[str] = ()
+        self.static_include_patterns: Iterable[str] | None = None
+        self.static_exclude_patterns: Iterable[str] | None = None
+        self.static_exclude_dirs: Iterable[str] | None = None
+        self.static_include_dirs: Iterable[str] | None = None
+        self.include_static_in_site_map: bool = True
         if not route_list:
             return
         self.update(route_list)
@@ -115,28 +117,32 @@ class SiteMap:
             self._route_map[sm_entry.slug] = sm_entry
             if sm_entry.entries:
                 self._collections[sm_entry.slug] = sm_entry
-        if self.static_paths:
+        if self.static_paths and self.include_static_in_site_map:
             self.add_static_files(
                 self.static_paths,
                 include_patterns=self.static_include_patterns,
                 exclude_patterns=self.static_exclude_patterns,
                 exclude_dirs=self.static_exclude_dirs,
+                include_dirs=self.static_include_dirs,
             )
 
     def add_static_files(
         self,
         static_paths: Iterable[str | Path],
-        include_patterns: Iterable[str] = ("*",),
-        exclude_patterns: Iterable[str] = (),
-        exclude_dirs: Iterable[str] = (),
+        include_patterns: Iterable[str] | None = None,
+        exclude_patterns: Iterable[str] | None = None,
+        exclude_dirs: Iterable[str] | None = None,
+        include_dirs: Iterable[str] | None = None,
     ) -> None:
         """
         Add static files to the site map, optionally filtered by pattern or directory.
 
         :param static_paths: Static directories to include in the site map
-        :param include_patterns: Glob patterns a file must match to be included. Defaults to all files.
+        :param include_patterns: Glob patterns a file must match to be included. Default None: no filtering.
         :param exclude_patterns: Glob patterns that exclude a matching file even if it matched an include pattern.
         :param exclude_dirs: Directory names to skip entirely (matched against any path segment).
+        :param include_dirs: Subdirectory paths that override exclude_dirs, forcing inclusion for matching
+            subdirectories even if a parent directory was excluded.
         """
         for static in static_paths:
             static = Path(static)
@@ -146,12 +152,19 @@ class SiteMap:
             for file_path in static.rglob("*"):
                 if not file_path.is_file():
                     continue
-                rel_parts = file_path.relative_to(static).parts[:-1]
-                if exclude_dirs and any(part in exclude_dirs for part in rel_parts):
+                rel_dir = file_path.relative_to(static).parent
+                rel_parts = rel_dir.parts
+                rel_dir_str = rel_dir.as_posix()
+
+                excluded_by_dir = exclude_dirs is not None and any(part in exclude_dirs for part in rel_parts)
+                included_override = include_dirs is not None and any(
+                    rel_dir_str == d or rel_dir_str.startswith(f"{d}/") for d in include_dirs
+                )
+                if excluded_by_dir and not included_override:
                     continue
-                if not any(file_path.match(p) for p in include_patterns):
+                if include_patterns is not None and not any(file_path.match(p) for p in include_patterns):
                     continue
-                if exclude_patterns and any(file_path.match(p) for p in exclude_patterns):
+                if exclude_patterns is not None and any(file_path.match(p) for p in exclude_patterns):
                     continue
                 entry = StaticSiteMapEntry(file_path, static, url_prefix)
                 self._route_map[entry.slug] = entry

--- a/src/render_engine/site_map.py
+++ b/src/render_engine/site_map.py
@@ -88,7 +88,7 @@ class SiteMap:
         self.static_exclude_patterns: Iterable[str] | None = None
         self.static_exclude_dirs: Iterable[str] | None = None
         self.static_include_dirs: Iterable[str] | None = None
-        self.include_static_in_site_map: bool = True
+        self.include_static_in_site_map: bool = False
         if not route_list:
             return
         self.update(route_list)

--- a/src/render_engine/site_map.py
+++ b/src/render_engine/site_map.py
@@ -162,7 +162,7 @@ class SiteMap:
                 )
                 if excluded_by_dir and not included_override:
                     continue
-                if include_patterns is not None and not any(file_path.match(p) for p in include_patterns):
+                if include_patterns and not any(file_path.match(p) for p in include_patterns):
                     continue
                 if exclude_patterns is not None and any(file_path.match(p) for p in exclude_patterns):
                     continue

--- a/src/render_engine/site_map.py
+++ b/src/render_engine/site_map.py
@@ -164,7 +164,7 @@ class SiteMap:
                     continue
                 if include_patterns and not any(file_path.match(p) for p in include_patterns):
                     continue
-                if exclude_patterns is not None and any(file_path.match(p) for p in exclude_patterns):
+                if exclude_patterns and any(file_path.match(p) for p in exclude_patterns):
                     continue
                 entry = StaticSiteMapEntry(file_path, static, url_prefix)
                 self._route_map[entry.slug] = entry

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -477,6 +477,7 @@ def test_static_files_appear_in_site_map_after_render(tmp_path: Path):
     site = Site()
     site.output_path = tmp_path / "output"
     site.static_paths.add(static_dir)
+    site.include_static_in_site_map = True
 
     @site.page
     class CustomPage(Page):
@@ -498,6 +499,7 @@ def test_static_files_appear_in_xml_site_map(tmp_path: Path):
     site = Site()
     site.output_path = tmp_path / "output"
     site.static_paths.add(static_dir)
+    site.include_static_in_site_map = True
     site.render_xml_site_map = True
 
     @site.page
@@ -519,6 +521,7 @@ def test_nested_static_files_appear_in_site_map(tmp_path: Path):
     site = Site()
     site.output_path = tmp_path / "output"
     site.static_paths.add(static_dir)
+    site.include_static_in_site_map = True
 
     @site.page
     class CustomPage(Page):

--- a/tests/test_site_map.py
+++ b/tests/test_site_map.py
@@ -288,6 +288,37 @@ def test_add_static_files_exclude_dirs_skips_directory(tmp_path):
     assert urls == ["/static/logo.png"]
 
 
+def test_add_static_files_include_dirs_overrides_exclude_dirs(tmp_path):
+    static_dir = tmp_path / "static"
+    (static_dir / "drafts" / "public").mkdir(parents=True)
+    (static_dir / "drafts" / "private").mkdir(parents=True)
+    (static_dir / "drafts" / "public" / "notice.png").write_text("a")
+    (static_dir / "drafts" / "private" / "secret.png").write_text("b")
+    (static_dir / "logo.png").write_text("c")
+
+    sm = SiteMap("http://example.com")
+    sm.add_static_files(
+        [static_dir],
+        exclude_dirs=["drafts"],
+        include_dirs=["drafts/public"],
+    )
+
+    urls = sorted(entry.url_for for entry in sm)
+    assert urls == ["/static/drafts/public/notice.png", "/static/logo.png"]
+
+
+def test_include_static_in_site_map_false_excludes_from_map(tmp_path):
+    static_dir = tmp_path / "static"
+    static_dir.mkdir()
+    (static_dir / "logo.png").write_text("a")
+
+    sm = SiteMap("", {}, static_paths=[static_dir])
+    sm.include_static_in_site_map = False
+    sm.update({})
+
+    assert list(sm) == []
+
+
 def test_site_static_filters_apply_through_render(tmp_path_factory):
     base_temp_path = tmp_path_factory.getbasetemp()
     static_dir = base_temp_path / "filtered_static"

--- a/tests/test_site_map.py
+++ b/tests/test_site_map.py
@@ -338,9 +338,23 @@ def test_site_static_filters_apply_through_render(tmp_path_factory):
         static_paths = {static_dir}
         static_include_patterns = ("*.png",)
         static_exclude_dirs = ("drafts",)
+        include_static_in_site_map = True
 
     filtered_site = FilteredSite()
     filtered_site.render()
 
     urls = sorted(entry.url_for for entry in filtered_site.site_map if isinstance(entry, StaticSiteMapEntry))
     assert urls == [f"/{static_dir.name}/logo.png"]
+
+
+def test_include_static_in_site_map_true_includes_in_map(tmp_path):
+    static_dir = tmp_path / "static"
+    static_dir.mkdir()
+    (static_dir / "logo.png").write_text("a")
+
+    sm = SiteMap("", {}, static_paths=[static_dir])
+    sm.include_static_in_site_map = True
+    sm.update({})
+
+    urls = sorted(entry.url_for for entry in sm)
+    assert urls == ["/static/logo.png"]

--- a/tests/test_site_map.py
+++ b/tests/test_site_map.py
@@ -247,3 +247,69 @@ def test_add_static_files_can_be_found_via_site_map_find(tmp_path):
     assert found is not None
     assert found.title == "logo.png"
     assert sm.find("/static/missing.png", attr="url_for") is None
+
+
+def test_add_static_files_include_patterns_filters_files(tmp_path):
+    static_dir = tmp_path / "static"
+    static_dir.mkdir()
+    (static_dir / "logo.png").write_text("a")
+    (static_dir / "notes.txt").write_text("b")
+
+    sm = SiteMap("http://example.com")
+    sm.add_static_files([static_dir], include_patterns=["*.png"])
+
+    urls = sorted(entry.url_for for entry in sm)
+    assert urls == ["/static/logo.png"]
+
+
+def test_add_static_files_exclude_patterns_filters_files(tmp_path):
+    static_dir = tmp_path / "static"
+    static_dir.mkdir()
+    (static_dir / "logo.png").write_text("a")
+    (static_dir / "logo.png.bak").write_text("b")
+
+    sm = SiteMap("http://example.com")
+    sm.add_static_files([static_dir], exclude_patterns=["*.bak"])
+
+    urls = sorted(entry.url_for for entry in sm)
+    assert urls == ["/static/logo.png"]
+
+
+def test_add_static_files_exclude_dirs_skips_directory(tmp_path):
+    static_dir = tmp_path / "static"
+    (static_dir / "drafts").mkdir(parents=True)
+    (static_dir / "logo.png").write_text("a")
+    (static_dir / "drafts" / "wip.png").write_text("b")
+
+    sm = SiteMap("http://example.com")
+    sm.add_static_files([static_dir], exclude_dirs=["drafts"])
+
+    urls = sorted(entry.url_for for entry in sm)
+    assert urls == ["/static/logo.png"]
+
+
+def test_site_static_filters_apply_through_render(tmp_path_factory):
+    base_temp_path = tmp_path_factory.getbasetemp()
+    static_dir = base_temp_path / "filtered_static"
+    static_dir.mkdir(exist_ok=True)
+    (static_dir / "logo.png").write_text("a")
+    (static_dir / "notes.txt").write_text("b")
+    (static_dir / "drafts").mkdir(exist_ok=True)
+    (static_dir / "drafts" / "wip.png").write_text("c")
+
+    tmp_output_path = base_temp_path / "filtered_output"
+    tmp_template_path = base_temp_path / "filtered_templates"
+    tmp_template_path.mkdir(exist_ok=True)
+
+    class FilteredSite(Site):
+        output_path = tmp_output_path
+        _template_path = tmp_template_path
+        static_paths = {static_dir}
+        static_include_patterns = ("*.png",)
+        static_exclude_dirs = ("drafts",)
+
+    filtered_site = FilteredSite()
+    filtered_site.render()
+
+    urls = sorted(entry.url_for for entry in filtered_site.site_map if isinstance(entry, StaticSiteMapEntry))
+    assert urls == [f"/{static_dir.name}/logo.png"]


### PR DESCRIPTION
<!--
SUMMARY OF THE CHANGES BEING MADE
Be sure to include any referenced issues and discussions.
Not following this guideline will result in the immediate rejection of your PR.
-->

Fixes #1233

Adds optional include/exclude filtering for static files in the `SiteMap`. Per brass75's comment on the issue, configuration lives on `Site` rather than being passed directly to `SiteMap` methods: `Site.static_include_patterns`, `Site.static_exclude_patterns`, and `Site.static_exclude_dirs` are threaded through `SiteMap.update()` into `SiteMap.add_static_files()`, following the same pattern already used for `Site.static_paths`.

- `static_include_patterns`: glob patterns a file must match to be included. Default `("*",)` — matches current behavior, all files included.
- `static_exclude_patterns`: glob patterns that exclude a file even if it matched an include pattern. Default `()`.
- `static_exclude_dirs`: directory names to skip entirely, matched against any path segment. Default `()`.

The issue's fifth requirement, disabling static data in the site map entirely, is already supported by existing behavior: `SiteMap.update()` only calls `add_static_files` when `static_paths` is truthy, so setting `static_paths=set()` on `Site` already opts out. No new code was needed for that part.

#### Type of Issue

- [ ] :bug: (bug)
- [ ] :book: (Documentation)
- [ ] :arrow_up: (Update)
- [x] :dizzy: (New Feature)
- [ ] :radioactive: (Deprecation)
- [ ] :no_entry_sign: (Removal)
- [ ] :hammer_and_wrench: (Refactor)

#### Changes have been Documented (If Applicable)

- [x] YES - Changes have been documented

#### Changes have been Tested

- [x] YES - Changes have been tested. 4 new tests added: 3 unit-level on `add_static_files` (include patterns, exclude patterns, exclude dirs), 1 integration-level exercising the full `Site` -> `SiteMap.render()` wiring. Full suite passes (156 passed, 1 skipped), `ruff check`, `ruff format --check`, and `ty check` all clean.

#### Next Steps

<!--ANY FURTHER STEPS TO BE TAKEN-->
None anticipated. Open to feedback on the API shape (kwarg names, tuple vs other iterable types) if a different convention is preferred.

#### AI Attestation

<!-- Include how AI was used in the creation of this change -->
AI was used to help analyze the existing codebase conventions (`Collection.include_suffixes`, PR #1228 review history) and review the implementation approach before writing code.