### PR TITLE
Update permissions for publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ jobs:
     uses: ./.github/workflows/test.yml
     permissions:
       contents: read
+      pull-requests: write # This is needed for the coverage badge. Will fail on startup without it.
 
   build:
     needs: test


### PR DESCRIPTION
This fixes an issue with permissions in `publish.yml` caused by the coverage badge generation needing write permission for PRs. 